### PR TITLE
Do not throw exception when deprecated headers are missing

### DIFF
--- a/src/main/java/com/cdancy/jenkins/rest/domain/system/SystemInfo.java
+++ b/src/main/java/com/cdancy/jenkins/rest/domain/system/SystemInfo.java
@@ -37,15 +37,6 @@ public abstract class SystemInfo implements ErrorsHolder {
 
     public abstract String jenkinsSession();
 
-    @Nullable
-    public abstract String hudsonCLIPort();
-
-    @Nullable
-    public abstract String jenkinsCLIPort();
-
-    @Nullable
-    public abstract String jenkinsCLI2Port();
-
     public abstract String instanceIdentity();
 
     @Nullable
@@ -57,14 +48,12 @@ public abstract class SystemInfo implements ErrorsHolder {
     }
 
     @SerializedNames({ "hudsonVersion", "jenkinsVersion", "jenkinsSession",
-        "hudsonCLIPort", "jenkinsCLIPort", "jenkinsCLI2Port",
         "instanceIdentity", "sshEndpoint", "server", "errors" })
     public static SystemInfo create(String hudsonVersion, String jenkinsVersion, String jenkinsSession,
-            String hudsonCLIPort, String jenkinsCLIPort, String jenkinsCLI2Port, String instanceIdentity,
+            String instanceIdentity,
             String sshEndpoint, String server, final List<Error> errors) {
         return new AutoValue_SystemInfo(JenkinsUtils.nullToEmpty(errors),
                 hudsonVersion, jenkinsVersion, jenkinsSession, 
-                hudsonCLIPort, jenkinsCLIPort, jenkinsCLI2Port,
                 instanceIdentity, sshEndpoint, server);
     }
 }

--- a/src/main/java/com/cdancy/jenkins/rest/domain/system/SystemInfo.java
+++ b/src/main/java/com/cdancy/jenkins/rest/domain/system/SystemInfo.java
@@ -37,10 +37,13 @@ public abstract class SystemInfo implements ErrorsHolder {
 
     public abstract String jenkinsSession();
 
+    @Nullable
     public abstract String hudsonCLIPort();
 
+    @Nullable
     public abstract String jenkinsCLIPort();
 
+    @Nullable
     public abstract String jenkinsCLI2Port();
 
     public abstract String instanceIdentity();

--- a/src/main/java/com/cdancy/jenkins/rest/fallbacks/JenkinsFallbacks.java
+++ b/src/main/java/com/cdancy/jenkins/rest/fallbacks/JenkinsFallbacks.java
@@ -87,7 +87,6 @@ public final class JenkinsFallbacks {
     public static SystemInfo createSystemInfoFromErrors(final List<Error> errors) {
         final String illegalValue = "-1";
         return SystemInfo.create(illegalValue, illegalValue, illegalValue,
-                illegalValue, illegalValue, illegalValue,
                 illegalValue, illegalValue, illegalValue, errors);
     }
 

--- a/src/main/java/com/cdancy/jenkins/rest/parsers/SystemInfoFromJenkinsHeaders.java
+++ b/src/main/java/com/cdancy/jenkins/rest/parsers/SystemInfoFromJenkinsHeaders.java
@@ -37,8 +37,7 @@ public class SystemInfoFromJenkinsHeaders implements Function<HttpResponse, Syst
         final int statusCode = response.getStatusCode();
         if (statusCode >= 200 && statusCode < 400) {
             return SystemInfo.create(response.getFirstHeaderOrNull("X-Hudson"), response.getFirstHeaderOrNull("X-Jenkins"),
-                response.getFirstHeaderOrNull("X-Jenkins-Session"), response.getFirstHeaderOrNull("X-Hudson-CLI-Port"),
-                response.getFirstHeaderOrNull("X-Jenkins-CLI-Port"), response.getFirstHeaderOrNull("X-Jenkins-CLI2-Port"),
+                response.getFirstHeaderOrNull("X-Jenkins-Session"),
                 response.getFirstHeaderOrNull("X-Instance-Identity"), response.getFirstHeaderOrNull("X-SSH-Endpoint"),
                 response.getFirstHeaderOrNull("Server"), null);
         } else {


### PR DESCRIPTION
This fixes #2 

This lets me call `SystemInfo systemInfo = client.api().systemApi().systemInfo();` against Jenkins 2.107.1.

To recap, more recent versions of Jenkins no longer send these headers:
* X-Hudson-CLI-Port
* X-Jenkins-CLI-Port
* X-Jenkins-CLI2-Port
