### PR TITLE
CrumbIssuer.crumb now returns boxed version of its former self so tha…

### DIFF
--- a/src/main/java/com/cdancy/jenkins/rest/domain/crumb/Crumb.java
+++ b/src/main/java/com/cdancy/jenkins/rest/domain/crumb/Crumb.java
@@ -14,28 +14,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.cdancy.jenkins.rest.features;
 
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertTrue;
+package com.cdancy.jenkins.rest.domain.crumb;
 
-import org.testng.annotations.Test;
+import java.util.List;
 
-import com.cdancy.jenkins.rest.BaseJenkinsApiLiveTest;
-import com.cdancy.jenkins.rest.domain.crumb.Crumb;
+import org.jclouds.javax.annotation.Nullable;
+import org.jclouds.json.SerializedNames;
 
-@Test(groups = "live", testName = "CrumbIssuerApiLiveTest", singleThreaded = true)
-public class CrumbIssuerApiLiveTest extends BaseJenkinsApiLiveTest {
+import com.cdancy.jenkins.rest.domain.common.Error;
+import com.cdancy.jenkins.rest.domain.common.ErrorsHolder;
+import com.cdancy.jenkins.rest.domain.common.Value;
+import com.cdancy.jenkins.rest.JenkinsUtils;
+import com.google.auto.value.AutoValue;
 
-    @Test
-    public void testGetCrumb() {
-        final Crumb crumb = api().crumb();
-        assertNotNull(crumb);
-        assertNotNull(crumb.value());
-        assertTrue(crumb.errors().isEmpty());
-    }
+@AutoValue
+public abstract class Crumb implements Value<String>, ErrorsHolder {
 
-    private CrumbIssuerApi api() {
-        return api.crumbIssuerApi();
+    @SerializedNames({ "value", "errors" })
+    public static Crumb create(@Nullable final String value,
+            final List<Error> errors) {
+
+        return new AutoValue_Crumb(value,
+                JenkinsUtils.nullToEmpty(errors));
     }
 }

--- a/src/main/java/com/cdancy/jenkins/rest/features/CrumbIssuerApi.java
+++ b/src/main/java/com/cdancy/jenkins/rest/features/CrumbIssuerApi.java
@@ -23,18 +23,25 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.MediaType;
 
+import org.jclouds.rest.annotations.Fallback;
+import org.jclouds.rest.annotations.ResponseParser;
 import org.jclouds.rest.annotations.RequestFilters;
 import org.jclouds.rest.annotations.QueryParams;
 
+import com.cdancy.jenkins.rest.domain.crumb.Crumb;
+import com.cdancy.jenkins.rest.fallbacks.JenkinsFallbacks;
 import com.cdancy.jenkins.rest.filters.JenkinsNoCrumbAuthenticationFilter;
+import com.cdancy.jenkins.rest.parsers.CrumbParser;
 
 @RequestFilters(JenkinsNoCrumbAuthenticationFilter.class)
 @Path("/crumbIssuer/api/xml")
 public interface CrumbIssuerApi {
 
     @Named("crumb-issuer:crumb")
+    @Fallback(JenkinsFallbacks.CrumbOnError.class)
+    @ResponseParser(CrumbParser.class)
     @QueryParams(keys = { "xpath" }, values = { "concat(//crumbRequestField,\":\",//crumb)" })
     @Consumes(MediaType.TEXT_PLAIN)
     @GET
-    String crumb();
+    Crumb crumb();
 }

--- a/src/main/java/com/cdancy/jenkins/rest/filters/JenkinsAuthenticationFilter.java
+++ b/src/main/java/com/cdancy/jenkins/rest/filters/JenkinsAuthenticationFilter.java
@@ -37,7 +37,6 @@ import org.jclouds.rest.ResourceNotFoundException;
 public class JenkinsAuthenticationFilter implements HttpRequestFilter {
     private final JenkinsAuthentication creds;
     private final JenkinsApi jenkinsApi;
-    //private static volatile Crumb crumbValue = null; // can be shared across requests
 
     // key = Crumb, value = true if exception is ResourceNotFoundException false otherwise
     private static volatile Pair<Crumb, Boolean> crumbPair = null; 

--- a/src/main/java/com/cdancy/jenkins/rest/filters/JenkinsAuthenticationFilter.java
+++ b/src/main/java/com/cdancy/jenkins/rest/filters/JenkinsAuthenticationFilter.java
@@ -60,7 +60,7 @@ public class JenkinsAuthenticationFilter implements HttpRequestFilter {
 
             // whether to add crumb header or not
             final Pair<Crumb, Boolean> localCrumb = getCrumb();
-            if (localCrumb.getKey() != null) {
+            if (localCrumb.getKey().value() != null) {
                 builder.addHeader(CRUMB_HEADER, localCrumb.getKey().value());
             } else {
                 if (localCrumb.getValue() == false) {

--- a/src/main/java/com/cdancy/jenkins/rest/handlers/JenkinsErrorHandler.java
+++ b/src/main/java/com/cdancy/jenkins/rest/handlers/JenkinsErrorHandler.java
@@ -30,7 +30,6 @@ import org.jclouds.http.HttpCommand;
 import org.jclouds.http.HttpErrorHandler;
 import org.jclouds.http.HttpResponse;
 import org.jclouds.http.HttpResponseException;
-import org.jclouds.logging.Logger;
 import org.jclouds.rest.ResourceAlreadyExistsException;
 import org.jclouds.rest.ResourceNotFoundException;
 import org.jclouds.rest.AuthorizationException;
@@ -42,8 +41,6 @@ import com.google.common.base.Throwables;
  * Handle errors and propagate exception
  */
 public class JenkinsErrorHandler implements HttpErrorHandler {
-   @Resource
-   protected Logger logger = Logger.NULL;
 
     @Override
     public void handleError(final HttpCommand command, final HttpResponse response) {

--- a/src/main/java/com/cdancy/jenkins/rest/parsers/CrumbParser.java
+++ b/src/main/java/com/cdancy/jenkins/rest/parsers/CrumbParser.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cdancy.jenkins.rest.parsers;
+
+import com.cdancy.jenkins.rest.domain.crumb.Crumb;
+
+import com.google.common.base.Function;
+import java.io.IOException;
+
+import javax.inject.Singleton;
+
+import org.jclouds.http.HttpResponse;
+import org.jclouds.util.Strings2;
+
+/**
+ * Turn a valid response, but one that has no body, into a Crumb.
+ */
+@Singleton
+public class CrumbParser implements Function<HttpResponse, Crumb> {
+
+    @Override
+    public Crumb apply(final HttpResponse input) {
+        final int statusCode = input.getStatusCode();
+        if (statusCode >= 200 && statusCode < 400) {
+            try {
+                final String response = Strings2.toStringAndClose(input.getPayload().openStream());
+                return Crumb.create(response.split(":")[1], null);
+            } catch (final IOException e) {
+                throw new RuntimeException(input.getStatusLine(), e);
+            }
+        } else {
+            throw new RuntimeException(input.getStatusLine());
+        }
+    }
+}

--- a/src/test/java/com/cdancy/jenkins/rest/features/CrumbIssuerApiMockTest.java
+++ b/src/test/java/com/cdancy/jenkins/rest/features/CrumbIssuerApiMockTest.java
@@ -23,6 +23,7 @@ import org.testng.annotations.Test;
 
 import com.cdancy.jenkins.rest.JenkinsApi;
 import com.cdancy.jenkins.rest.BaseJenkinsMockTest;
+import com.cdancy.jenkins.rest.domain.crumb.Crumb;
 
 import com.squareup.okhttp.mockwebserver.MockResponse;
 import com.squareup.okhttp.mockwebserver.MockWebServer;
@@ -38,14 +39,14 @@ public class CrumbIssuerApiMockTest extends BaseJenkinsMockTest {
     public void testGetSystemInfo() throws Exception {
         MockWebServer server = mockWebServer();
 
-        final String body = "";
-        server.enqueue(new MockResponse().setBody("Jenkins-Crumb:04a1109fc2db171362c966ebe9fc87f0").setResponseCode(200));
+        final String value = "04a1109fc2db171362c966ebe9fc87f0";
+        server.enqueue(new MockResponse().setBody("Jenkins-Crumb:" + value).setResponseCode(200));
         JenkinsApi jenkinsApi = api(server.getUrl("/"));
         CrumbIssuerApi api = jenkinsApi.crumbIssuerApi();
         try {
-            final String instance = api.crumb();
+            final Crumb instance = api.crumb();
             assertNotNull(instance);
-            assertTrue(instance.contains(":"));
+            assertTrue(instance.value().equals(value));
             assertSentAccept(server, "GET", "/crumbIssuer/api/xml?xpath=concat%28//crumbRequestField,%22%3A%22,//crumb%29", MediaType.TEXT_PLAIN);
         } finally {
             jenkinsApi.close();


### PR DESCRIPTION
@martinda this PR addresses #14 . The `CrumbIssuer.crumb` endpoint can now be checked for `errors()`. We then take advantage of this in the authentication filter to check whether the call returns a 404/ResourceNotFoundException and if so simply ignore adding the crumb to the request otherwise throw an exception with the `error` attached.

Check it out and let me know what you think.