### PR TITLE
Simple optional path to jobs api

### DIFF
--- a/src/main/java/com/cdancy/jenkins/rest/JenkinsUtils.java
+++ b/src/main/java/com/cdancy/jenkins/rest/JenkinsUtils.java
@@ -46,6 +46,9 @@ import java.util.Collections;
 import java.util.Enumeration;
 import java.util.Objects;
 import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import org.jclouds.javax.annotation.Nullable;
 
 /**
@@ -60,7 +63,7 @@ public class JenkinsUtils {
 
     /**
      * Convert passed Iterable into an ImmutableList.
-     * 
+     *
      * @param <T> an arbitrary type.
      * @param input the Iterable to copy.
      * @return ImmutableList or empty ImmutableList if `input` is null.
@@ -71,7 +74,7 @@ public class JenkinsUtils {
 
     /**
      * Convert passed Map into an ImmutableMap.
-     * 
+     *
      * @param <K> an arbitrary type.
      * @param <V> an arbitrary type.
      * @param input the Map to copy.
@@ -83,7 +86,7 @@ public class JenkinsUtils {
 
     /**
      * Convert passed Map into a JsonElement.
-     * 
+     *
      * @param input the Map to convert.
      * @return JsonElement or empty JsonElement if `input` is null.
      */
@@ -93,7 +96,7 @@ public class JenkinsUtils {
 
     /**
      * Convert passed Map into a JsonElement.
-     * 
+     *
      * @param input the Map to convert.
      * @return JsonElement or empty JsonElement if `input` is null.
      */
@@ -103,7 +106,7 @@ public class JenkinsUtils {
 
     /**
      * Convert passed String into a JsonElement.
-     * 
+     *
      * @param input the String to convert.
      * @return JsonElement or empty JsonElement if `input` is null.
      */
@@ -117,7 +120,7 @@ public class JenkinsUtils {
      * was found, and environmentVariable is non-null, we will attempt to
      * query the `Environment Variables` for a value and return it. If
      * both are either null or can't be found than null will be returned.
-     * 
+     *
      * @param systemProperty possibly existent System Property.
      * @param environmentVariable possibly existent Environment Variable.
      * @return found external value or null.
@@ -189,7 +192,7 @@ public class JenkinsUtils {
     /**
      * Find jclouds overrides (e.g. Properties) first searching within System
      * Properties and then within Environment Variables (former takes precedance).
-     * 
+     *
      * @return Properties object with populated jclouds properties.
      */
     public static Properties inferOverrides() {
@@ -222,13 +225,13 @@ public class JenkinsUtils {
                 }
             }
         }
-        
+
         return overrides;
     }
 
     /**
      * Add the passed environment variables to the currently existing env-vars.
-     * 
+     *
      * @param addEnvVars the env-vars to add.
      */
     public static void addEnvironmentVariables(final Map<String, String> addEnvVars) {
@@ -240,7 +243,7 @@ public class JenkinsUtils {
 
     /**
      * Remove the passed environment variables keys from the environment.
-     * 
+     *
      * @param removeEnvVars the env-var keys to be removed.
      */
     public static void removeEnvironmentVariables(final Collection<String> removeEnvVars) {
@@ -252,7 +255,7 @@ public class JenkinsUtils {
 
     /**
      * Re-set the environment variables with passed map.
-     * 
+     *
      * @param newEnvVars map to reset env-vars with.
      */
     public static void setEnvironmentVariables(final Map<String, String> newEnvVars) {
@@ -286,6 +289,36 @@ public class JenkinsUtils {
                 }
             }
         }
+    }
+
+    /**
+     * amend the path to job by appending "/job/" before every folder name
+     *
+     * @param folderPath simple folder path expression
+     *
+     * @return amendedFodlerPath which optional folder
+     *         path reconstructed to match the jenkins URL style.
+     */
+    public static String amendFolderPath(String folderPath) {
+        Pattern pattern = Pattern.compile("(job/[^!@#$%^&*<>]+/*)+");
+        Matcher m = pattern.matcher(folderPath);
+        if(m.matches()) {
+            return folderPath;
+        }
+
+        if(folderPath.startsWith("/") || folderPath.endsWith("/")) {
+            throw new RuntimeException("Incorrect folder Path format - " + folderPath);
+        }
+
+        String amendedPath = "";
+        String[] folderNames = folderPath.split("/");
+        for (int i=0; i<folderNames.length; i++) {
+            amendedPath += "job/" + folderNames[i];
+            if(i < folderNames.length-1) {
+                amendedPath += "/";
+            }
+        }
+        return amendedPath;
     }
 
     protected JenkinsUtils() {

--- a/src/main/java/com/cdancy/jenkins/rest/features/JobsApi.java
+++ b/src/main/java/com/cdancy/jenkins/rest/features/JobsApi.java
@@ -35,6 +35,7 @@ import org.jclouds.Fallbacks;
 import org.jclouds.javax.annotation.Nullable;
 import org.jclouds.rest.annotations.BinderParam;
 import org.jclouds.rest.annotations.Fallback;
+import org.jclouds.rest.annotations.ParamParser;
 import org.jclouds.rest.annotations.Payload;
 import org.jclouds.rest.annotations.PayloadParam;
 import org.jclouds.rest.annotations.RequestFilters;
@@ -53,6 +54,7 @@ import com.cdancy.jenkins.rest.parsers.BuildNumberToInteger;
 import com.cdancy.jenkins.rest.parsers.LocationToQueueId;
 import com.cdancy.jenkins.rest.parsers.OutputToProgressiveText;
 import com.cdancy.jenkins.rest.parsers.RequestStatusParser;
+import com.cdancy.jenkins.rest.parsers.optionalFolderPathParser;
 
 import static com.cdancy.jenkins.rest.JenkinsConstants.OPTIONAL_FOLDER_PATH_PARAM;
 
@@ -66,7 +68,7 @@ public interface JobsApi {
     @Fallback(Fallbacks.NullOnNotFoundOr404.class)
     @Consumes(MediaType.APPLICATION_JSON)
     @GET
-    JobInfo jobInfo(@Nullable @PathParam(OPTIONAL_FOLDER_PATH_PARAM) String optionalFolderPath,
+    JobInfo jobInfo(@Nullable @PathParam(OPTIONAL_FOLDER_PATH_PARAM) @ParamParser(optionalFolderPathParser.class) String optionalFolderPath,
                     @PathParam("name") String jobName);
 
     @Named("jobs:build-info")
@@ -75,7 +77,7 @@ public interface JobsApi {
     @Fallback(Fallbacks.NullOnNotFoundOr404.class)
     @Consumes(MediaType.APPLICATION_JSON)
     @GET
-    BuildInfo buildInfo(@Nullable @PathParam(OPTIONAL_FOLDER_PATH_PARAM) String optionalFolderPath,
+    BuildInfo buildInfo(@Nullable @PathParam(OPTIONAL_FOLDER_PATH_PARAM) @ParamParser(optionalFolderPathParser.class) String optionalFolderPath,
                         @PathParam("name") String jobName,
                         @PathParam("number") int buildNumber);
 
@@ -88,7 +90,7 @@ public interface JobsApi {
     @Consumes(MediaType.WILDCARD)
     @Payload("{configXML}")
     @POST
-    RequestStatus create(@Nullable @PathParam(OPTIONAL_FOLDER_PATH_PARAM) String optionalFolderPath,
+    RequestStatus create(@Nullable @PathParam(OPTIONAL_FOLDER_PATH_PARAM) @ParamParser(optionalFolderPathParser.class) String optionalFolderPath,
                          @QueryParam("name") String jobName,
                          @PayloadParam(value = "configXML") String configXML);
 
@@ -98,7 +100,7 @@ public interface JobsApi {
     @Fallback(Fallbacks.NullOnNotFoundOr404.class)
     @Consumes(MediaType.TEXT_PLAIN)
     @GET
-    String config(@Nullable @PathParam(OPTIONAL_FOLDER_PATH_PARAM) String optionalFolderPath,
+    String config(@Nullable @PathParam(OPTIONAL_FOLDER_PATH_PARAM) @ParamParser(optionalFolderPathParser.class) String optionalFolderPath,
                   @PathParam("name") String jobName);
 
     @Named("jobs:update-config")
@@ -109,7 +111,7 @@ public interface JobsApi {
     @Consumes(MediaType.TEXT_HTML)
     @Payload("{configXML}")
     @POST
-    boolean config(@Nullable @PathParam(OPTIONAL_FOLDER_PATH_PARAM) String optionalFolderPath,
+    boolean config(@Nullable @PathParam(OPTIONAL_FOLDER_PATH_PARAM) @ParamParser(optionalFolderPathParser.class) String optionalFolderPath,
                    @PathParam("name") String jobName,
                    @PayloadParam(value = "configXML") String configXML);
 
@@ -119,7 +121,7 @@ public interface JobsApi {
     @Fallback(Fallbacks.NullOnNotFoundOr404.class)
     @Consumes(MediaType.TEXT_PLAIN)
     @GET
-    String description(@Nullable @PathParam(OPTIONAL_FOLDER_PATH_PARAM) String optionalFolderPath,
+    String description(@Nullable @PathParam(OPTIONAL_FOLDER_PATH_PARAM) @ParamParser(optionalFolderPathParser.class) String optionalFolderPath,
                        @PathParam("name") String jobName);
 
     @Named("jobs:set-description")
@@ -128,7 +130,7 @@ public interface JobsApi {
     @Fallback(Fallbacks.FalseOnNotFoundOr404.class)
     @Consumes(MediaType.TEXT_HTML)
     @POST
-    boolean description(@Nullable @PathParam(OPTIONAL_FOLDER_PATH_PARAM) String optionalFolderPath,
+    boolean description(@Nullable @PathParam(OPTIONAL_FOLDER_PATH_PARAM) @ParamParser(optionalFolderPathParser.class) String optionalFolderPath,
                         @PathParam("name") String jobName,
                         @FormParam("description") String description);
 
@@ -139,7 +141,7 @@ public interface JobsApi {
     @Fallback(JenkinsFallbacks.RequestStatusOnError.class)
     @ResponseParser(RequestStatusParser.class)
     @POST
-    RequestStatus delete(@Nullable @PathParam(OPTIONAL_FOLDER_PATH_PARAM) String optionalFolderPath,
+    RequestStatus delete(@Nullable @PathParam(OPTIONAL_FOLDER_PATH_PARAM) @ParamParser(optionalFolderPathParser.class) String optionalFolderPath,
                          @PathParam("name") String jobName);
 
     @Named("jobs:enable")
@@ -148,7 +150,7 @@ public interface JobsApi {
     @Fallback(Fallbacks.FalseOnNotFoundOr404.class)
     @Consumes(MediaType.TEXT_HTML)
     @POST
-    boolean enable(@Nullable @PathParam(OPTIONAL_FOLDER_PATH_PARAM) String optionalFolderPath,
+    boolean enable(@Nullable @PathParam(OPTIONAL_FOLDER_PATH_PARAM) @ParamParser(optionalFolderPathParser.class) String optionalFolderPath,
                    @PathParam("name") String jobName);
 
     @Named("jobs:disable")
@@ -157,7 +159,7 @@ public interface JobsApi {
     @Fallback(Fallbacks.FalseOnNotFoundOr404.class)
     @Consumes(MediaType.TEXT_HTML)
     @POST
-    boolean disable(@Nullable @PathParam(OPTIONAL_FOLDER_PATH_PARAM) String optionalFolderPath,
+    boolean disable(@Nullable @PathParam(OPTIONAL_FOLDER_PATH_PARAM) @ParamParser(optionalFolderPathParser.class) String optionalFolderPath,
                     @PathParam("name") String jobName);
 
     @Named("jobs:build")
@@ -167,7 +169,7 @@ public interface JobsApi {
     @ResponseParser(LocationToQueueId.class)
     @Consumes("application/unknown")
     @POST
-    IntegerResponse build(@Nullable @PathParam(OPTIONAL_FOLDER_PATH_PARAM) String optionalFolderPath,
+    IntegerResponse build(@Nullable @PathParam(OPTIONAL_FOLDER_PATH_PARAM) @ParamParser(optionalFolderPathParser.class) String optionalFolderPath,
                   @PathParam("name") String jobName);
 
     @Named("jobs:build-with-params")
@@ -177,7 +179,7 @@ public interface JobsApi {
     @ResponseParser(LocationToQueueId.class)
     @Consumes("application/unknown")
     @POST
-    IntegerResponse buildWithParameters(@Nullable @PathParam(OPTIONAL_FOLDER_PATH_PARAM) String optionalFolderPath,
+    IntegerResponse buildWithParameters(@Nullable @PathParam(OPTIONAL_FOLDER_PATH_PARAM) @ParamParser(optionalFolderPathParser.class) String optionalFolderPath,
                                 @PathParam("name") String jobName,
                                 @BinderParam(BindMapToForm.class) Map<String, List<String>> properties);
 
@@ -188,7 +190,7 @@ public interface JobsApi {
     @ResponseParser(BuildNumberToInteger.class)
     @Consumes(MediaType.TEXT_PLAIN)
     @GET
-    Integer lastBuildNumber(@Nullable @PathParam(OPTIONAL_FOLDER_PATH_PARAM) String optionalFolderPath,
+    Integer lastBuildNumber(@Nullable @PathParam(OPTIONAL_FOLDER_PATH_PARAM) @ParamParser(optionalFolderPathParser.class) String optionalFolderPath,
                             @PathParam("name") String jobName);
 
     @Named("jobs:last-build-timestamp")
@@ -197,7 +199,7 @@ public interface JobsApi {
     @Fallback(Fallbacks.NullOnNotFoundOr404.class)
     @Consumes(MediaType.TEXT_PLAIN)
     @GET
-    String lastBuildTimestamp(@Nullable @PathParam(OPTIONAL_FOLDER_PATH_PARAM) String optionalFolderPath,
+    String lastBuildTimestamp(@Nullable @PathParam(OPTIONAL_FOLDER_PATH_PARAM) @ParamParser(optionalFolderPathParser.class) String optionalFolderPath,
                               @PathParam("name") String jobName);
 
     @Named("jobs:progressive-text")
@@ -207,7 +209,7 @@ public interface JobsApi {
     @ResponseParser(OutputToProgressiveText.class)
     @Consumes(MediaType.TEXT_PLAIN)
     @GET
-    ProgressiveText progressiveText(@Nullable @PathParam(OPTIONAL_FOLDER_PATH_PARAM) String optionalFolderPath,
+    ProgressiveText progressiveText(@Nullable @PathParam(OPTIONAL_FOLDER_PATH_PARAM) @ParamParser(optionalFolderPathParser.class) String optionalFolderPath,
                                     @PathParam("name") String jobName,
                                     @QueryParam("start") int start);
 }

--- a/src/main/java/com/cdancy/jenkins/rest/parsers/optionalFolderPathParser.java
+++ b/src/main/java/com/cdancy/jenkins/rest/parsers/optionalFolderPathParser.java
@@ -1,0 +1,21 @@
+package com.cdancy.jenkins.rest.parsers;
+
+import com.cdancy.jenkins.rest.JenkinsUtils;
+import com.google.common.base.Function;
+
+import javax.inject.Singleton;
+
+/*
+ * Turn the optionalFolderPath param to jenkins URL style if needed
+ */
+@Singleton
+public class optionalFolderPathParser implements Function<Object,String> {
+
+    @Override
+    public String apply(Object optionalFolderPath) {
+        if(optionalFolderPath != null) {
+            return JenkinsUtils.amendFolderPath(String.class.cast(optionalFolderPath));
+        }
+        return null;
+    }
+}

--- a/src/test/java/com/cdancy/jenkins/rest/features/JobsApiLiveTest.java
+++ b/src/test/java/com/cdancy/jenkins/rest/features/JobsApiLiveTest.java
@@ -27,6 +27,8 @@ import java.util.Map;
 
 import com.cdancy.jenkins.rest.domain.plugins.Plugin;
 import com.cdancy.jenkins.rest.domain.plugins.Plugins;
+import com.cdancy.jenkins.rest.filters.ScrubNullFolderParam;
+import org.jclouds.http.HttpRequest;
 import org.testng.annotations.Test;
 
 import com.cdancy.jenkins.rest.BaseJenkinsApiLiveTest;
@@ -215,53 +217,105 @@ public class JobsApiLiveTest extends BaseJenkinsApiLiveTest {
     }
 
     @Test(dependsOnMethods = "testInstallFolderPlugin")
-    public void testCreateFolderInJenkins() {
+    public void testCreateFoldersInJenkins() {
         String config = payloadFromResource("/folder-config.xml");
-        RequestStatus success = api().create(null, "test-folder", config);
+        RequestStatus success1 = api().create(null, "test-folder", config);
+        assertTrue(success1.value());
+        RequestStatus success2 = api().create("job/test-folder", "test-folder-1", config);
+        assertTrue(success2.value());
+    }
+
+    @Test(dependsOnMethods = "testCreateFoldersInJenkins")
+    public void testCreateJobInFolder() {
+        String config = payloadFromResource("/freestyle-project-no-params.xml");
+        RequestStatus success = api().create("job/test-folder/job/test-folder-1", "JobInFolder", config);
         assertTrue(success.value());
     }
 
-    @Test(dependsOnMethods = "testCreateFolderInJenkins")
-    public void testCreateJobInFolder() {
-        String config = payloadFromResource("/freestyle-project-no-params.xml");
-        RequestStatus success = api().create("job/test-folder", "JobInFolder", config);
-        assertTrue(success.value());
+    @Test(dependsOnMethods = "testCreateFoldersInJenkins")
+    public void testCreateJobWithIncorrectFolderPathFormatOne() {
+        try {
+            String jobConfig = payloadFromResource("/freestyle-project-no-params.xml");
+            RequestStatus success = api().create("/test-folder/test-folder-1/", "JobInFolder", jobConfig);
+        } catch(Exception e) {
+            assertTrue(e.getMessage().contains("Incorrect folder Path format"));
+        }
+    }
+
+    @Test(dependsOnMethods = "testCreateFoldersInJenkins")
+    public void testCreateJobWithIncorrectFolderPathFormatTwo() {
+        try {
+            String jobConfig = payloadFromResource("/freestyle-project-no-params.xml");
+            RequestStatus success = api().create("//test-folder/test-folder-1", "JobInFolder", jobConfig);
+        } catch(Exception e) {
+            assertTrue(e.getMessage().contains("Incorrect folder Path format"));
+        }
+    }
+
+    @Test(dependsOnMethods = "testCreateFoldersInJenkins")
+    public void testCreateJobWithIncorrectFolderPathFormatThree() {
+        try {
+            String jobConfig = payloadFromResource("/freestyle-project-no-params.xml");
+            RequestStatus success = api().create("test-folder/test-folder-1//", "JobInFolder", jobConfig);
+        } catch(Exception e) {
+            assertTrue(e.getMessage().contains("Incorrect folder Path format"));
+        }
+    }
+
+    @Test(dependsOnMethods = "testCreateFoldersInJenkins")
+    public void testCreateJobWithIncorrectFolderPathFormatFour() {
+        try {
+            String jobConfig = payloadFromResource("/freestyle-project-no-params.xml");
+            RequestStatus success = api().create("/test-foldertest-folder-1", "JobInFolder", jobConfig);
+        } catch(Exception e) {
+            assertTrue(e.getMessage().contains("Incorrect folder Path format"));
+        }
+    }
+
+    @Test(dependsOnMethods = "testCreateFoldersInJenkins")
+    public void testCreateJobWithIncorrectFolderPathFormatFive() {
+        try {
+            String jobConfig = payloadFromResource("/freestyle-project-no-params.xml");
+            RequestStatus success = api().create("/job/test-folder/job/test-folder-1", "JobInFolder", jobConfig);
+        } catch(Exception e) {
+            assertTrue(e.getMessage().contains("Incorrect folder Path format"));
+        }
     }
 
     @Test(dependsOnMethods = "testCreateJobInFolder")
     public void testUpdateJobConfigInFolder() {
         String config = payloadFromResource("/freestyle-project.xml");
-        boolean success = api().config("job/test-folder", "JobInFolder", config);
+        boolean success = api().config("job/test-folder/job/test-folder-1", "JobInFolder", config);
         assertTrue(success);
     }
 
     @Test(dependsOnMethods = "testUpdateJobConfigInFolder")
     public void testDisableJobInFolder() {
-        boolean success = api().disable("job/test-folder", "JobInFolder");
+        boolean success = api().disable("job/test-folder/job/test-folder-1", "JobInFolder");
         assertTrue(success);
     }
 
     @Test(dependsOnMethods = "testDisableJobInFolder")
     public void testEnableJobInFolder() {
-        boolean success = api().enable("job/test-folder", "JobInFolder");
+        boolean success = api().enable("job/test-folder/job/test-folder-1", "JobInFolder");
         assertTrue(success);
     }
 
     @Test(dependsOnMethods = "testEnableJobInFolder")
     public void testSetDescriptionOfJobInFolder() {
-        boolean success = api().description("job/test-folder", "JobInFolder", "RandomDescription");
+        boolean success = api().description("job/test-folder/job/test-folder-1", "JobInFolder", "RandomDescription");
         assertTrue(success);
     }
 
     @Test(dependsOnMethods = "testSetDescriptionOfJobInFolder")
     public void testGetDescriptionOfJobInFolder() {
-        String output = api().description("job/test-folder", "JobInFolder");
+        String output = api().description("job/test-folder/job/test-folder-1", "JobInFolder");
         assertTrue(output.equals("RandomDescription"));
     }
 
     @Test(dependsOnMethods = "testGetDescriptionOfJobInFolder")
     public void testGetJobInfoInFolder() {
-        JobInfo output = api().jobInfo("job/test-folder", "JobInFolder");
+        JobInfo output = api().jobInfo("job/test-folder/job/test-folder-1", "JobInFolder");
         assertNotNull(output);
         assertTrue(output.name().equals("JobInFolder"));
         assertTrue(output.builds().isEmpty());
@@ -271,20 +325,20 @@ public class JobsApiLiveTest extends BaseJenkinsApiLiveTest {
     public void testBuildWithParameters() {
         Map<String, List<String>> params = new HashMap<>();
         params.put("SomeKey", Lists.newArrayList("SomeVeryNewValue"));
-        queueIdForAnotherJob = api().buildWithParameters("job/test-folder", "JobInFolder", params);
+        queueIdForAnotherJob = api().buildWithParameters("test-folder/test-folder-1", "JobInFolder", params);
         assertNotNull(queueIdForAnotherJob);
         assertTrue(queueIdForAnotherJob.value() > 0);
     }
 
     @Test(dependsOnMethods = "testBuildWithParameters")
     public void testLastBuildTimestampOfJobInFolder() {
-        String output = api().lastBuildTimestamp("job/test-folder", "JobInFolder");
+        String output = api().lastBuildTimestamp("test-folder/test-folder-1", "JobInFolder");
         assertNotNull(output);
     }
 
     @Test(dependsOnMethods = "testLastBuildTimestampOfJobInFolder")
     public void testGetProgressiveText() {
-        ProgressiveText output = api().progressiveText("job/test-folder", "JobInFolder", 0);
+        ProgressiveText output = api().progressiveText("test-folder/test-folder-1", "JobInFolder", 0);
         assertNotNull(output);
         assertTrue(output.size() > 0);
         assertFalse(output.hasMoreData());
@@ -292,7 +346,7 @@ public class JobsApiLiveTest extends BaseJenkinsApiLiveTest {
 
     @Test(dependsOnMethods = "testGetProgressiveText")
     public void testGetBuildInfoOfJobInFolder() {
-        BuildInfo output = api().buildInfo("job/test-folder", "JobInFolder", 1);
+        BuildInfo output = api().buildInfo("test-folder/test-folder-1", "JobInFolder", 1);
         assertNotNull(output);
         assertTrue(output.fullDisplayName().contains("JobInFolder #1"));
         assertTrue(output.queueId() == queueIdForAnotherJob.value());
@@ -300,14 +354,16 @@ public class JobsApiLiveTest extends BaseJenkinsApiLiveTest {
 
     @Test(dependsOnMethods = "testGetBuildInfoOfJobInFolder")
     public void testDeleteJobInFolder() {
-        RequestStatus success = api().delete("job/test-folder", "JobInFolder");
+        RequestStatus success = api().delete("test-folder/test-folder-1", "JobInFolder");
         assertTrue(success.value());
     }
 
     @Test(dependsOnMethods = "testDeleteJobInFolder")
-    public void testDeleteFolder() {
-        RequestStatus success = api().delete(null, "test-folder");
-        assertTrue(success.value());
+    public void testDeleteFolders() {
+        RequestStatus success1 = api().delete("test-folder", "test-folder-1");
+        assertTrue(success1.value());
+        RequestStatus success2 = api().delete(null, "test-folder");
+        assertTrue(success2.value());
     }
 
     @Test

--- a/src/test/java/com/cdancy/jenkins/rest/features/JobsApiMockTest.java
+++ b/src/test/java/com/cdancy/jenkins/rest/features/JobsApiMockTest.java
@@ -156,6 +156,25 @@ public class JobsApiMockTest extends BaseJenkinsMockTest {
         }
     }
 
+    public void testSimpleFolderPath() throws Exception {
+        MockWebServer server = mockWebServer();
+
+        String configXML = payloadFromResource("/freestyle-project.xml");
+        server.enqueue(new MockResponse().setResponseCode(200));
+        JenkinsApi jenkinsApi = api(server.getUrl("/"));
+        JobsApi api = jenkinsApi.jobsApi();
+        try {
+            RequestStatus success = api.create("test-folder/test-folder-1", "JobInFolder", configXML);
+            assertNotNull(success);
+            assertTrue(success.value());
+            assertTrue(success.errors().isEmpty());
+            assertSentWithXMLFormDataAccept(server, "POST", "/job/test-folder/job/test-folder-1/createItem?name=JobInFolder", configXML, MediaType.WILDCARD);
+        } finally {
+            jenkinsApi.close();
+            server.shutdown();
+        }
+    }
+
     public void testCreateJobAlreadyExists() throws Exception {
         MockWebServer server = mockWebServer();
 


### PR DESCRIPTION
@cdancy @martinda - This pull-request is for issue#21 

I tried to get the value of  `@PathParam(OPTIONAL_FOLDER_PATH_PARAM) String optionalFolderPath'  variable inside the filter method of ScrubNullFolderParam.java, I was not successful. I think the values of pathparam variables were resolved already in the filter method.

But I found an annotation in jclouds called `@ParamParser` [here](https://jclouds.apache.org/reference/javadoc/1.8.x/org/jclouds/rest/annotations/ParamParser.html) which can intercept the path parameter variable values of the request. I have an initial implementation of this feature. I do have live tests for this change and it works locally for me. Let me know what you guys think.
