### PR TITLE
Feature: quietDown and cancelQuietDown

### DIFF
--- a/src/main/java/com/cdancy/jenkins/rest/features/SystemApi.java
+++ b/src/main/java/com/cdancy/jenkins/rest/features/SystemApi.java
@@ -20,9 +20,12 @@ package com.cdancy.jenkins.rest.features;
 import javax.inject.Named;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.HEAD;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.MediaType;
 
+import com.cdancy.jenkins.rest.domain.common.RequestStatus;
+import com.cdancy.jenkins.rest.parsers.RequestStatusParser;
 import org.jclouds.rest.annotations.RequestFilters;
 import org.jclouds.rest.annotations.ResponseParser;
 import org.jclouds.rest.annotations.Fallback;
@@ -42,4 +45,21 @@ public interface SystemApi {
    @ResponseParser(SystemInfoFromJenkinsHeaders.class)
    @HEAD
    SystemInfo systemInfo();
+
+   @Named("system:quiet-down")
+   @Path("quietDown")
+   @Fallback(JenkinsFallbacks.RequestStatusOnError.class)
+   @ResponseParser(RequestStatusParser.class)
+   @Consumes(MediaType.TEXT_HTML)
+   @POST
+   RequestStatus quietDown();
+
+   @Named("system:cancel-quiet-down")
+   @Path("cancelQuietDown")
+   @Fallback(JenkinsFallbacks.RequestStatusOnError.class)
+   @ResponseParser(RequestStatusParser.class)
+   @Consumes(MediaType.TEXT_HTML)
+   @POST
+   RequestStatus cancelQuietDown();
+
 }

--- a/src/test/java/com/cdancy/jenkins/rest/features/SystemApiLiveTest.java
+++ b/src/test/java/com/cdancy/jenkins/rest/features/SystemApiLiveTest.java
@@ -19,6 +19,7 @@ package com.cdancy.jenkins.rest.features;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
+import com.cdancy.jenkins.rest.domain.common.RequestStatus;
 import org.testng.annotations.Test;
 
 import com.cdancy.jenkins.rest.BaseJenkinsApiLiveTest;
@@ -32,6 +33,21 @@ public class SystemApiLiveTest extends BaseJenkinsApiLiveTest {
         final SystemInfo version = api().systemInfo();
         assertNotNull(version);
         assertTrue(version.jenkinsVersion() != null);
+    }
+
+    @Test
+    public void testQuietDown() {
+        RequestStatus success = api().quietDown();
+        assertNotNull(success);
+        assertTrue(success.value());
+    }
+
+    @Test(dependsOnMethods = "testQuietDown")
+    public void testCancelQuietDown() {
+        RequestStatus success = api().cancelQuietDown();
+        assertNotNull(success);
+        assertTrue(success.value());
+
     }
 
     private SystemApi api() {

--- a/src/test/java/com/cdancy/jenkins/rest/features/SystemApiLiveTest.java
+++ b/src/test/java/com/cdancy/jenkins/rest/features/SystemApiLiveTest.java
@@ -43,11 +43,24 @@ public class SystemApiLiveTest extends BaseJenkinsApiLiveTest {
     }
 
     @Test(dependsOnMethods = "testQuietDown")
+    public void testAlreadyQuietDown() {
+        RequestStatus success = api().quietDown();
+        assertNotNull(success);
+        assertTrue(success.value());
+    }
+
+    @Test(dependsOnMethods = "testAlreadyQuietDown")
     public void testCancelQuietDown() {
         RequestStatus success = api().cancelQuietDown();
         assertNotNull(success);
         assertTrue(success.value());
+    }
 
+    @Test(dependsOnMethods = "testCancelQuietDown")
+    public void testAlreadyCanceledQuietDown() {
+        RequestStatus success = api().cancelQuietDown();
+        assertNotNull(success);
+        assertTrue(success.value());
     }
 
     private SystemApi api() {


### PR DESCRIPTION
Issue: #53

**quietDown** sends the Quiet Down (Prepare for shutdown) message to Jenkins
**cancelQuietDown** cancels the Quiet Down message

These two endpoints should be tested together, so I put them in one Pull Request.

