### PR TITLE
fix crumb issue with Jenkins 2.176.2+/2.186+

### DIFF
--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -1,5 +1,4 @@
-# api calls 403 error with jenkins 2.176.2+/2.186+ because of security changes: https://jenkins.io/security/advisory/2019-07-17/#SECURITY-626
-ARG jenkins_tag=2.176.1-alpine
+ARG jenkins_tag=2.190.3-alpine
 
 FROM jenkins/jenkins:$jenkins_tag
 

--- a/src/main/java/com/cdancy/jenkins/rest/JenkinsConstants.java
+++ b/src/main/java/com/cdancy/jenkins/rest/JenkinsConstants.java
@@ -41,6 +41,8 @@ public class JenkinsConstants {
 
     public static final String OPTIONAL_FOLDER_PATH_PARAM = "optionalFolderPath";
 
+    public static final String JENKINS_COOKIES_JSESSIONID = "JSESSIONID";
+
     protected JenkinsConstants() {
         throw new UnsupportedOperationException("Purposefully not implemented");
     }

--- a/src/main/java/com/cdancy/jenkins/rest/domain/crumb/Crumb.java
+++ b/src/main/java/com/cdancy/jenkins/rest/domain/crumb/Crumb.java
@@ -24,18 +24,34 @@ import org.jclouds.json.SerializedNames;
 
 import com.cdancy.jenkins.rest.domain.common.Error;
 import com.cdancy.jenkins.rest.domain.common.ErrorsHolder;
-import com.cdancy.jenkins.rest.domain.common.Value;
 import com.cdancy.jenkins.rest.JenkinsUtils;
 import com.google.auto.value.AutoValue;
 
 @AutoValue
-public abstract class Crumb implements Value<String>, ErrorsHolder {
+public abstract class Crumb implements ErrorsHolder {
+
+    @Nullable
+    public abstract String value();
+
+    @Nullable
+    public abstract String sessionIdCookie();
 
     @SerializedNames({ "value", "errors" })
-    public static Crumb create(@Nullable final String value,
+    public static Crumb create(final String value,
             final List<Error> errors) {
 
-        return new AutoValue_Crumb(value,
-                JenkinsUtils.nullToEmpty(errors));
+        return create(value, null, errors);
+    }
+
+    @SerializedNames({ "value", "sessionIdCookie" })
+    public static Crumb create(final String value, final String sessionIdCookie) {
+        return create(value, sessionIdCookie, null);
+    }
+
+    private static Crumb create(final String value, final String sessionIdCookie,
+            final List<Error> errors) {
+
+        return new AutoValue_Crumb(JenkinsUtils.nullToEmpty(errors), value,
+                sessionIdCookie);
     }
 }

--- a/src/main/java/com/cdancy/jenkins/rest/filters/JenkinsAuthenticationFilter.java
+++ b/src/main/java/com/cdancy/jenkins/rest/filters/JenkinsAuthenticationFilter.java
@@ -39,7 +39,7 @@ public class JenkinsAuthenticationFilter implements HttpRequestFilter {
     private final JenkinsApi jenkinsApi;
 
     // key = Crumb, value = true if exception is ResourceNotFoundException false otherwise
-    private static volatile Pair<Crumb, Boolean> crumbPair = null; 
+    private static volatile Pair<Crumb, Boolean> crumbPair = null;
     private static final String CRUMB_HEADER = "Jenkins-Crumb";
 
     @Inject
@@ -61,6 +61,7 @@ public class JenkinsAuthenticationFilter implements HttpRequestFilter {
             final Pair<Crumb, Boolean> localCrumb = getCrumb();
             if (localCrumb.getKey().value() != null) {
                 builder.addHeader(CRUMB_HEADER, localCrumb.getKey().value());
+                builder.addHeader(HttpHeaders.COOKIE, localCrumb.getKey().sessionIdCookie());
             } else {
                 if (localCrumb.getValue() == false) {
                     throw new RuntimeException("Unexpected exception being thrown: error=" + localCrumb.getKey().errors().get(0));
@@ -87,7 +88,7 @@ public class JenkinsAuthenticationFilter implements HttpRequestFilter {
         }
         return crumbValueInit;
     }
- 
+
     // simple impl/copy of javafx.util.Pair
     private class Pair<A, B> {
         private final A a;

--- a/src/main/java/com/cdancy/jenkins/rest/filters/JenkinsAuthenticationFilter.java
+++ b/src/main/java/com/cdancy/jenkins/rest/filters/JenkinsAuthenticationFilter.java
@@ -63,7 +63,7 @@ public class JenkinsAuthenticationFilter implements HttpRequestFilter {
             if (localCrumb.getKey().value() != null) {
                 builder.addHeader(CRUMB_HEADER, localCrumb.getKey().value());
                 Optional.ofNullable(localCrumb.getKey().sessionIdCookie())
-                        .ifPresent(sessionId -> builder.addHeader(sessionId));
+                        .ifPresent(sessionId -> builder.addHeader(HttpHeaders.COOKIE, sessionId));
             } else {
                 if (localCrumb.getValue() == false) {
                     throw new RuntimeException("Unexpected exception being thrown: error=" + localCrumb.getKey().errors().get(0));

--- a/src/main/java/com/cdancy/jenkins/rest/filters/JenkinsAuthenticationFilter.java
+++ b/src/main/java/com/cdancy/jenkins/rest/filters/JenkinsAuthenticationFilter.java
@@ -17,6 +17,7 @@
 
 package com.cdancy.jenkins.rest.filters;
 
+import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
@@ -61,7 +62,8 @@ public class JenkinsAuthenticationFilter implements HttpRequestFilter {
             final Pair<Crumb, Boolean> localCrumb = getCrumb();
             if (localCrumb.getKey().value() != null) {
                 builder.addHeader(CRUMB_HEADER, localCrumb.getKey().value());
-                builder.addHeader(HttpHeaders.COOKIE, localCrumb.getKey().sessionIdCookie());
+                Optional.ofNullable(localCrumb.getKey().sessionIdCookie())
+                        .ifPresent(sessionId -> builder.addHeader(sessionId));
             } else {
                 if (localCrumb.getValue() == false) {
                     throw new RuntimeException("Unexpected exception being thrown: error=" + localCrumb.getKey().errors().get(0));

--- a/src/main/java/com/cdancy/jenkins/rest/parsers/CrumbParser.java
+++ b/src/main/java/com/cdancy/jenkins/rest/parsers/CrumbParser.java
@@ -57,6 +57,6 @@ public class CrumbParser implements Function<HttpResponse, Crumb> {
         return input.getHeaders().get(HttpHeaders.SET_COOKIE).stream()
             .filter(c -> c.startsWith("JSESSIONID"))
             .findFirst()
-            .orElse(null);
+            .orElse("");
     }
 }

--- a/src/main/java/com/cdancy/jenkins/rest/parsers/CrumbParser.java
+++ b/src/main/java/com/cdancy/jenkins/rest/parsers/CrumbParser.java
@@ -17,6 +17,8 @@
 
 package com.cdancy.jenkins.rest.parsers;
 
+import static com.cdancy.jenkins.rest.JenkinsConstants.JENKINS_COOKIES_JSESSIONID;
+
 import com.cdancy.jenkins.rest.domain.crumb.Crumb;
 
 import com.google.common.base.Function;
@@ -55,7 +57,7 @@ public class CrumbParser implements Function<HttpResponse, Crumb> {
 
     private static String sessionIdCookie(HttpResponse input) {
         return input.getHeaders().get(HttpHeaders.SET_COOKIE).stream()
-            .filter(c -> c.startsWith("JSESSIONID"))
+            .filter(c -> c.startsWith(JENKINS_COOKIES_JSESSIONID))
             .findFirst()
             .orElse("");
     }


### PR DESCRIPTION
Always pass the JSESSIONID in addition to the crumb
See https://jenkins.io/security/advisory/2019-07-17/#SECURITY-626

closes #67

**Implementation note**
I am not used to playing with AutoValue and jclouds, so don't hesitate to spot any bad practices on these areas 😸 