### PR TITLE
Introduce jenkins docker container for integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,18 @@ cache:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
 
+services:
+  - docker
+
+before_install:
+  - docker build -t jenkins-rest/jenkins src/main/docker
+  - docker run -d --rm -p 8080:8080 --name jenkins-rest jenkins-rest/jenkins
+
 install: true
     
 script:
-  - ./gradlew -s -Dorg.gradle.daemon=false clean build mockTest publishToMavenLocal
+  - ./gradlew -s -Dorg.gradle.daemon=false clean build mockTest publishToMavenLocal integTest
 
 after_script:
+  - docker stop jenkins-rest
   - bash <(curl -s https://codecov.io/bash)
-  

--- a/README.md
+++ b/README.md
@@ -83,7 +83,35 @@ Running mock tests can be done like so:
 Running integration tests can be done like so (requires existing jenkins instance):
 
 	./gradlew clean build integTest 
-	
+
+### Integration tests settings
+
+#### Jenkins instance requirements
+
+- a running instance accessible on http://127.0.0.1:8080 (can be changed in the gradle.properties file)
+- Jenkins security
+  - an `admin` user (credentials used by the tests can be changed in the gradle.properties file) with `ADMIN` role (required as the tests install plugins)
+  - [CSRF protection enabled](https://wiki.jenkins.io/display/JENKINS/CSRF+Protection). Not mandatory but [recommended by the Jenkins documentation](https://jenkins.io/doc/book/system-administration/security/#protect-users-of-jenkins-from-other-threats). The lib supports Jenkins instances with our without this protection (see #14)
+- Plugins
+  - [CloudBees Credentials](https://plugins.jenkins.io/cloudbees-credentials): otherwise an http 500 error occurs when accessing
+to http://127.0.0.1:8080/job/test-folder/job/test-folder-1/ `java.lang.NoClassDefFoundError: com/cloudbees/hudson/plugins/folder/properties/FolderCredentialsProvider`
+  - [OWASP Markup Formatter](https://plugins.jenkins.io/antisamy-markup-formatter) configured to use `Safe HTML`
+
+This project provides instructions to setup a [pre-configured Docker container](src/main/docker/README.md)
+
+#### Integration tests configuration
+
+- jenkins url and authentication method used by the tests are defined in the `gradle.properties` file
+- by default, tests use the `credentials` authentication but this can be changed to use the `token` authentication
+
+
+#### Running integration tests from within your IDE
+
+- the `integTest` gradle tasks set various System Properties
+- if you don't want to use gradle as tests runner in your IDE, configure the tests with the same kind of System Properties
+
+
+
 # Additional Resources
 
 * [Jenkins REST API](http://wiki.jenkins-ci.org/display/JENKINS/Remote+access+API)

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -1,6 +1,4 @@
 # api calls 403 error with jenkins 2.176.2+/2.186+ because of security changes: https://jenkins.io/security/advisory/2019-07-17/#SECURITY-626
-#ARG jenkins_tag=2.190.1-alpine
-# api calls succeed
 ARG jenkins_tag=2.176.1-alpine
 
 FROM jenkins/jenkins:$jenkins_tag

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -1,0 +1,16 @@
+# api calls 403 error with jenkins 2.176.2+/2.186+ because of security changes: https://jenkins.io/security/advisory/2019-07-17/#SECURITY-626
+#ARG jenkins_tag=2.190.1-alpine
+# api calls succeed
+ARG jenkins_tag=2.176.1-alpine
+
+FROM jenkins/jenkins:$jenkins_tag
+
+COPY init.groovy.d/ /usr/share/jenkins/ref/init.groovy.d/
+
+# Plugins
+COPY plugins.txt /usr/share/jenkins/ref/plugins.txt
+# the grep command allows to ignore all comments in the plugins.txt file
+RUN xargs /usr/local/bin/install-plugins.sh `grep -v '^#' /usr/share/jenkins/ref/plugins.txt`
+
+# Skip initial setup
+ENV JAVA_OPTS -Djenkins.install.runSetupWizard=false

--- a/src/main/docker/README.md
+++ b/src/main/docker/README.md
@@ -1,0 +1,19 @@
+# Building and running a Jenkins master with Docker
+
+This Jenkins master image is configured to be used by integration tests, see the [main README](../../../../../README.md)
+
+
+Build the image
+```bash
+docker build -t jenkins-rest/jenkins .
+```
+
+You can decide which Jenkins version to used by passing the `jenkins_tag` docker build argument like in the following
+```bash
+docker build --build-arg jenkins_tag=2.164.3-slim -t jenkins-rest/jenkins .
+```
+
+Run the jenkins master container
+```bash
+docker run -d --rm -p 8080:8080 --name jenkins-rest jenkins-rest/jenkins
+```

--- a/src/main/docker/init.groovy.d/Security.groovy
+++ b/src/main/docker/init.groovy.d/Security.groovy
@@ -1,0 +1,36 @@
+import hudson.markup.RawHtmlMarkupFormatter
+import hudson.security.HudsonPrivateSecurityRealm
+import hudson.security.FullControlOnceLoggedInAuthorizationStrategy
+import hudson.security.csrf.DefaultCrumbIssuer
+import jenkins.model.Jenkins
+
+def instance = Jenkins.instanceOrNull
+
+// =====================================================================================================================
+// Allow html markup with syntax highlighting
+// =====================================================================================================================
+instance.setMarkupFormatter(new RawHtmlMarkupFormatter(false))
+
+
+// =====================================================================================================================
+// Enable CSRF protection (see: https://wiki.jenkins.io/display/JENKINS/CSRF+Protection)
+// =====================================================================================================================
+instance.setCrumbIssuer(new DefaultCrumbIssuer(true))
+
+
+// =====================================================================================================================
+// Create the admin user
+// =====================================================================================================================
+
+def jenkinsRealm = new HudsonPrivateSecurityRealm(false)
+jenkinsRealm.createAccount('admin', 'admin')
+instance.setSecurityRealm(jenkinsRealm)
+def strategy = new FullControlOnceLoggedInAuthorizationStrategy()
+strategy.setAllowAnonymousRead(true)
+instance.setAuthorizationStrategy(strategy)
+
+
+// =====================================================================================================================
+// Save everything
+// =====================================================================================================================
+instance.save()

--- a/src/main/docker/plugins.txt
+++ b/src/main/docker/plugins.txt
@@ -1,0 +1,2 @@
+antisamy-markup-formatter:1.6
+cloudbees-credentials:3.3

--- a/src/test/java/com/cdancy/jenkins/rest/features/JobsApiLiveTest.java
+++ b/src/test/java/com/cdancy/jenkins/rest/features/JobsApiLiveTest.java
@@ -41,7 +41,7 @@ import com.cdancy.jenkins.rest.domain.job.ProgressiveText;
 
 import com.google.common.collect.Lists;
 
-@Test(groups = "live", testName = "SystemApiLiveTest", singleThreaded = true)
+@Test(groups = "live", testName = "JobsApiLiveTest", singleThreaded = true)
 public class JobsApiLiveTest extends BaseJenkinsApiLiveTest {
 
     private IntegerResponse queueId;


### PR DESCRIPTION
This change now allows to let
  - Travis CI run integration
  - contributors run tests more easily

In addition, provide documentation about how to setup a Jenkins instance
targeted by tests

closes #72 