### PR TITLE
JobsApiLiveTest: fix test name

### DIFF
--- a/src/test/java/com/cdancy/jenkins/rest/features/JobsApiLiveTest.java
+++ b/src/test/java/com/cdancy/jenkins/rest/features/JobsApiLiveTest.java
@@ -41,7 +41,7 @@ import com.cdancy.jenkins.rest.domain.job.ProgressiveText;
 
 import com.google.common.collect.Lists;
 
-@Test(groups = "live", testName = "SystemApiLiveTest", singleThreaded = true)
+@Test(groups = "live", testName = "JobsApiLiveTest", singleThreaded = true)
 public class JobsApiLiveTest extends BaseJenkinsApiLiveTest {
 
     private IntegerResponse queueId;


### PR DESCRIPTION
The test had been named 'SystemApiLiveTest' probably by mistake when the class
had been created.

**Note**: no issue for this change