### PR TITLE
Added ChangeSets to BuildInfo

### DIFF
--- a/src/main/java/com/cdancy/jenkins/rest/domain/job/BuildInfo.java
+++ b/src/main/java/com/cdancy/jenkins/rest/domain/job/BuildInfo.java
@@ -64,6 +64,8 @@ public abstract class BuildInfo {
    @Nullable
    public abstract String url();
 
+   public abstract List<ChangeSetList> changeSets();
+   
    @Nullable
    public abstract String builtOn();
 
@@ -73,15 +75,17 @@ public abstract class BuildInfo {
    }
 
    @SerializedNames({ "artifacts", "actions", "building", "description", "displayName", "duration", "estimatedDuration",
-         "fullDisplayName", "id", "keepLog", "number", "queueId", "result", "timestamp", "url", "builtOn", "culprits" })
+         "fullDisplayName", "id", "keepLog", "number", "queueId", "result", "timestamp", "url", "changeSets", "builtOn", "culprits" })
    public static BuildInfo create(List<Artifact> artifacts, List<Action> actions, boolean building, String description, String displayName,
          long duration, long estimatedDuration, String fullDisplayName, String id, boolean keepLog, int number,
-         int queueId, String result, long timestamp, String url, String builtOn, List<Culprit> culprits) {
+         int queueId, String result, long timestamp, String url, List<ChangeSetList> changeSets, String builtOn, List<Culprit> culprits) {
       return new AutoValue_BuildInfo(
             artifacts != null ? ImmutableList.copyOf(artifacts) : ImmutableList.<Artifact> of(),
             actions != null ? ImmutableList.copyOf(actions) : ImmutableList.<Action> of(),
             building, description, displayName, duration, estimatedDuration, fullDisplayName,
-            id, keepLog, number, queueId, result, timestamp, url, builtOn,
+            id, keepLog, number, queueId, result, timestamp, url, 
+            changeSets != null ? ImmutableList.copyOf(changeSets) : ImmutableList.<ChangeSetList> of(),
+            builtOn,
             culprits != null ? ImmutableList.copyOf(culprits) : ImmutableList.<Culprit> of());
    }
 }

--- a/src/main/java/com/cdancy/jenkins/rest/domain/job/ChangeSet.java
+++ b/src/main/java/com/cdancy/jenkins/rest/domain/job/ChangeSet.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cdancy.jenkins.rest.domain.job;
+
+import java.util.List;
+
+import org.jclouds.javax.annotation.Nullable;
+import org.jclouds.json.SerializedNames;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
+
+@AutoValue
+public abstract class ChangeSet {
+
+   public abstract List<String> affectedPaths();
+
+   public abstract String commitId();
+
+   public abstract long timestamp();
+
+   public abstract Culprit author();
+
+   @Nullable
+   public abstract String authorEmail();
+
+   @Nullable
+   public abstract String comment();
+
+   ChangeSet() {
+   }
+
+   @SerializedNames({ "affectedPaths", "commitId", "timestamp", "author", "authorEmail", "comment" })
+   public static ChangeSet create(List<String> affectedPaths, String commitId, long timestamp, Culprit author, String authorEmail, String comment) {
+      return new AutoValue_ChangeSet(
+         affectedPaths != null ? ImmutableList.copyOf(affectedPaths) : ImmutableList.<String> of(), 
+         commitId, timestamp, author, authorEmail, comment);
+   }
+}

--- a/src/main/java/com/cdancy/jenkins/rest/domain/job/ChangeSetList.java
+++ b/src/main/java/com/cdancy/jenkins/rest/domain/job/ChangeSetList.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cdancy.jenkins.rest.domain.job;
+
+import java.util.List;
+
+import org.jclouds.javax.annotation.Nullable;
+import org.jclouds.json.SerializedNames;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
+
+@AutoValue
+public abstract class ChangeSetList {
+
+   public abstract List<ChangeSet> items();
+
+   @Nullable
+   public abstract String kind();
+
+   ChangeSetList() {
+   }
+
+   @SerializedNames({ "items", "kind" })
+   public static ChangeSetList create(List<ChangeSet> items, String kind) {
+      return new AutoValue_ChangeSetList(
+         items != null ? ImmutableList.copyOf(items) : ImmutableList.<ChangeSet> of(), 
+         kind);
+   }
+}

--- a/src/test/java/com/cdancy/jenkins/rest/features/JobsApiMockTest.java
+++ b/src/test/java/com/cdancy/jenkins/rest/features/JobsApiMockTest.java
@@ -625,6 +625,29 @@ public class JobsApiMockTest extends BaseJenkinsMockTest {
         }
     }
 
+    public void testGetGitCommitInfo() throws Exception {
+        MockWebServer server = mockWebServer();
+
+        String body = payloadFromResource("/build-info-git-commit.json");
+        server.enqueue(new MockResponse().setBody(body).setResponseCode(200));
+        JenkinsApi jenkinsApi = api(server.getUrl("/"));
+        JobsApi api = jenkinsApi.jobsApi();
+        try {
+            List<ChangeSet> changeSets = api.buildInfo(null,"fish", 10).changeSets().get(0).items();
+            assertNotNull(changeSets);
+            assertTrue(changeSets.get(0).affectedPaths().get(0).equals("some/path/in/the/repository"));
+            assertTrue(changeSets.get(0).commitId().equals("d27afa0805201322d846d7defc29b82c88d9b5ce"));
+            assertTrue(changeSets.get(0).timestamp() == 1461091892486l);
+            assertTrue(changeSets.get(0).author().absoluteUrl().equals("http://localhost:8080/user/username"));
+            assertTrue(changeSets.get(0).author().fullName().equals("username"));
+            assertTrue(changeSets.get(0).authorEmail().equals("username@localhost"));
+            assertTrue(changeSets.get(0).comment().equals("Commit comment\n"));
+        } finally {
+            jenkinsApi.close();
+            server.shutdown();
+        }
+    }
+
     public void testGetParamsWhenNoBuildParams() throws Exception {
         MockWebServer server = mockWebServer();
 

--- a/src/test/resources/build-info-git-commit.json
+++ b/src/test/resources/build-info-git-commit.json
@@ -1,0 +1,85 @@
+{
+  "actions" : [
+    {
+      "parameters" : [
+        {
+          "name" : "bear",
+          "value" : true
+        },
+        {
+          "name" : "fish",
+          "value" : "salmon"
+        }
+      ]
+    },
+    {
+      "causes" : [
+        {
+          "shortDescription" : "Started by user anonymous",
+          "userId" : null,
+          "userName" : "anonymous"
+        }
+      ]
+    }
+  ],
+  "artifacts" : [
+    {
+      "displayPath" : "fish.txt",
+      "fileName" : "fish.txt",
+      "relativePath" : "fish.txt"
+    }
+  ],
+  "building" : false,
+  "description" : null,
+  "displayName" : "#10",
+  "duration" : 60750,
+  "estimatedDuration" : 60258,
+  "executor" : null,
+  "fullDisplayName" : "fish #10",
+  "id" : "10",
+  "keepLog" : false,
+  "number" : 10,
+  "queueId" : 73,
+  "result" : "SUCCESS",
+  "timestamp" : 1461091892486,
+  "url" : "http://localhost:32769/job/fish/10/",
+  "builtOn" : "",
+  "changeSets" : [
+    {
+      "_class" : "hudson.plugins.git.GitChangeSetList",
+      "items" : [
+        {
+          "_class" : "hudson.plugins.git.GitChangeSet",
+          "affectedPaths" : [
+            "some/path/in/the/repository"
+          ],
+          "commitId" : "d27afa0805201322d846d7defc29b82c88d9b5ce",
+          "timestamp" : 1461091892486,
+          "author" : {
+            "absoluteUrl": "http://localhost:8080/user/username",
+            "fullName": "username"
+          },
+          "authorEmail" : "username@localhost",
+          "comment" : "Commit comment\n",
+          "date" : "2016-04-19 18:51:32 GMT",
+          "id" : "d27afa0805201322d846d7defc29b82c88d9b5ce",
+          "msg" : "Commit comment",
+          "paths" : [
+            {
+              "editType" : "add",
+              "file" : "some/path/in/the/repository"
+            }
+          ]
+        }
+      ],
+      "kind" : "git"
+    }
+    
+  ],
+  "culprits" : [
+    {
+        "absoluteUrl": "http://localhost:8080/user/username",
+        "fullName": "username"
+    }
+  ]
+}


### PR DESCRIPTION
Please do not create a Pull Request without first creating an ISSUE.
Any change needs to be discussed before proceeding.
Failure to do so may result in the rejection of the Pull Request.

Explain the **details** for making this change: What existing problem does the Pull Request solve? Why is this feature beneficial?

**On adding new feautes/endpoints**

No more than 1 endpoint should be coded within a Pull Request. 
This alone requires enough code to review and adding more than 1 WILL result in your Pull Request either being ignored or rejected outright.

**On adding Mock and Integ Tests**

At _least_ 2 mock tests and 2 integ tests are required prior to merging. 
Each pair should should test what the success and failure of added change looks like.
More complicated additions will of course require more tests.

**On CI testing (currently using travis)**

Code will not be reviewed until CI passes.
Current CI does NOT exercise `integ` tests and so each Pull Request will have to be run manually by one of the maintainers to confirm it works as expected: please be patient.

**On automtatic closing of ISSUES**

Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
