### PR TITLE
QueueItem.timestamp for items waiting in queue scheduled for later execution

### DIFF
--- a/src/main/java/com/cdancy/jenkins/rest/domain/queue/QueueItem.java
+++ b/src/main/java/com/cdancy/jenkins/rest/domain/queue/QueueItem.java
@@ -47,6 +47,12 @@ public abstract class QueueItem {
    @Nullable
    public abstract String why();
 
+    // https://javadoc.jenkins.io/hudson/model/Queue.NotWaitingItem.html
+    /**
+     * When did this job exit the Queue.waitingList phase?
+     * For a Queue.NotWaitingItem
+     * @return The time expressed in milliseconds after January 1, 1970, 0:00:00 GMT.
+     */
    public abstract long buildableStartMilliseconds();
 
    public abstract boolean cancelled();
@@ -54,14 +60,23 @@ public abstract class QueueItem {
    @Nullable
    public abstract Executable executable();
 
+    // https://javadoc.jenkins.io/hudson/model/Queue.WaitingItem.html
+    /**
+     * This item can be run after this time.
+     * For a Queue.WaitingItem
+     * @return The time expressed in milliseconds after January 1, 1970, 0:00:00 GMT.
+     */
+   @Nullable
+   public abstract Long timestamp();
+
    QueueItem() {
    }
 
    @SerializedNames({ "blocked", "buildable", "id", "inQueueSince", "params", "stuck", "task", "url", "why",
-         "buildableStartMilliseconds", "cancelled", "executable" })
+         "buildableStartMilliseconds", "cancelled", "executable", "timestamp"})
    public static QueueItem create(boolean blocked, boolean buildable, int id, long inQueueSince, String params,
          boolean stuck, Task task, String url, String why, long buildableStartMilliseconds,
-	 boolean cancelled, Executable executable) {
+	 boolean cancelled, Executable executable, Long timestamp) {
       Map<String, String> parameters = Maps.newHashMap();
       if (params != null) {
          params = params.trim();
@@ -73,6 +88,6 @@ public abstract class QueueItem {
          }
       }
       return new AutoValue_QueueItem(blocked, buildable, id, inQueueSince, parameters, stuck, task, url, why,
-            buildableStartMilliseconds, cancelled, executable);
+            buildableStartMilliseconds, cancelled, executable, timestamp);
    }
 }

--- a/src/main/java/com/cdancy/jenkins/rest/parsers/FolderPathParser.java
+++ b/src/main/java/com/cdancy/jenkins/rest/parsers/FolderPathParser.java
@@ -16,6 +16,10 @@ public class FolderPathParser implements Function<Object,String> {
 
     @Override
     public String apply(Object folderPath) {
+        if(folderPath == null) {
+            return EMPTY_STRING;
+        }
+
         final StringBuilder path = new StringBuilder((String) folderPath);
         if (path.length() == 0) {
             return EMPTY_STRING;
@@ -24,9 +28,17 @@ public class FolderPathParser implements Function<Object,String> {
         if(path.charAt(0) == FOLDER_NAME_SEPARATOR){
             path.deleteCharAt(0);
         }
+        if (path.length() == 0) {
+            return EMPTY_STRING;
+        }
+
         if(path.charAt(path.length() - 1) == FOLDER_NAME_SEPARATOR) {
             path.deleteCharAt(path.length() - 1);
         }
+        if (path.length() == 0) {
+            return EMPTY_STRING;
+        }
+
         final String[] folders = path.toString().split(Character.toString(FOLDER_NAME_SEPARATOR));
         path.setLength(0);
         for(final String folder : folders) {

--- a/src/main/java/com/cdancy/jenkins/rest/parsers/OptionalFolderPathParser.java
+++ b/src/main/java/com/cdancy/jenkins/rest/parsers/OptionalFolderPathParser.java
@@ -21,17 +21,30 @@ public class OptionalFolderPathParser implements Function<Object,String> {
         }
 
         final StringBuilder path = new StringBuilder(String.class.cast(optionalFolderPath));
+        if (path.length() == 0) {
+            return EMPTY_STRING;
+        }
+
         if(path.charAt(0) == FOLDER_NAME_SEPARATOR){
             path.deleteCharAt(0);
         }
+        if (path.length() == 0) {
+            return EMPTY_STRING;
+        }
+
         if(path.charAt(path.length() - 1) == FOLDER_NAME_SEPARATOR) {
             path.deleteCharAt(path.length() - 1);
         }
+        if (path.length() == 0) {
+            return EMPTY_STRING;
+        }
+
         final String[] folders = path.toString().split(Character.toString(FOLDER_NAME_SEPARATOR));
         path.setLength(0);
         for(final String folder : folders) {
             path.append(FOLDER_NAME_PREFIX).append(folder).append(FOLDER_NAME_SEPARATOR);
         }
+
         return path.toString();
     }
 }


### PR DESCRIPTION
- allow access to QueueItem.timestamp for items waiting in queue scheduled for later execution
- avoid index out of bounds exceptions in `OptionalFolderPathParser` and `FolderPathParser`
    * this permits "" and "/" as folderPath (e.g. `jobsApi.jobList("/")`) to fetch toplevel jobs