### PR TITLE
Fix null queue item task name

### DIFF
--- a/src/main/java/com/cdancy/jenkins/rest/domain/queue/Task.java
+++ b/src/main/java/com/cdancy/jenkins/rest/domain/queue/Task.java
@@ -17,6 +17,7 @@
 
 package com.cdancy.jenkins.rest.domain.queue;
 
+import org.jclouds.javax.annotation.Nullable;
 import org.jclouds.json.SerializedNames;
 
 import com.google.auto.value.AutoValue;
@@ -24,6 +25,7 @@ import com.google.auto.value.AutoValue;
 @AutoValue
 public abstract class Task {
 
+   @Nullable
    public abstract String name();
 
    public abstract String url();

--- a/src/test/java/com/cdancy/jenkins/rest/features/QueueApiMockTest.java
+++ b/src/test/java/com/cdancy/jenkins/rest/features/QueueApiMockTest.java
@@ -192,4 +192,23 @@ public class QueueApiMockTest extends BaseJenkinsMockTest {
             server.shutdown();
         }
     }
+
+    public void testQueueItemNullTaskName() throws Exception {
+        MockWebServer server = mockWebServer();
+        String body = payloadFromResource("/queueItemNullTaskName.json");
+        server.enqueue(new MockResponse().setBody(body).setResponseCode(200));
+        JenkinsApi jenkinsApi = api(server.getUrl("/"));
+        int queueItemId = 143;
+        QueueItem queueItem = jenkinsApi.queueApi().queueItem(queueItemId);
+        try {
+            assertFalse(queueItem.cancelled());
+            assertEquals(queueItem.why(), "Build #9 is already in progress (ETA:15 sec)");
+            assertNull(queueItem.executable());
+            assertSent(server, "GET", "/queue/item/" + queueItemId + "/api/json");
+        } finally {
+            jenkinsApi.close();
+            server.shutdown();
+        }
+    }
+
 }

--- a/src/test/resources/queueItemNullTaskName.json
+++ b/src/test/resources/queueItemNullTaskName.json
@@ -1,0 +1,41 @@
+{
+  "_class" : "hudson.model.Queue$BlockedItem",
+  "actions" : [
+    {
+      "_class" : "hudson.model.ParametersAction",
+      "parameters" : [
+        {
+          "_class" : "hudson.model.StringParameterValue",
+          "name" : "a",
+          "value" : "4"
+        }
+      ]
+    },
+    {
+      "_class" : "hudson.model.CauseAction",
+      "causes" : [
+        {
+          "_class" : "hudson.model.Cause$UserIdCause",
+          "shortDescription" : "Started by user martin",
+          "userId" : "martin",
+          "userName" : "martin"
+        }
+      ]
+    }
+  ],
+  "blocked" : true,
+  "buildable" : false,
+  "id" : 143,
+  "inQueueSince" : 1524074568030,
+  "params" : "\na=4",
+  "stuck" : false,
+  "task" : {
+    "_class" : "hudson.model.FreeStyleProject",
+    "name" : null,
+    "url" : "http://localhost:8082/job/test/",
+    "color" : "blue_anime"
+  },
+  "url" : "queue/item/143/",
+  "why" : "Build #9 is already in progress (ETA:15 sec)",
+  "buildableStartMilliseconds" : 1524074568030
+}


### PR DESCRIPTION
This solves Issue https://github.com/cdancy/jenkins-rest/issues/136

The QueueItem contains a Task whose name can be null in some yet to be reproduced cases.

The name property of Task was made Nullable.

* I added a mock test in the first commit.
* I added the solution in the second commit.

I do not have an integration test because I am not able to get Jenkins to reproduce the error.