### PR TITLE
Get test url from test.jenkins.endpoint property

### DIFF
--- a/src/test/java/com/cdancy/jenkins/rest/features/JobsApiLiveTest.java
+++ b/src/test/java/com/cdancy/jenkins/rest/features/JobsApiLiveTest.java
@@ -279,7 +279,7 @@ public class JobsApiLiveTest extends BaseJenkinsApiLiveTest {
         assertNotNull(output);
         assertFalse(output.jobs().isEmpty());
         assertEquals(output.jobs().size(), 1);
-        assertEquals(output.jobs().get(0), Job.create("hudson.model.FreeStyleProject", "JobInFolder", "http://127.0.0.1:8080/job/test-folder/job/test-folder-1/job/JobInFolder/", "notbuilt"));
+        assertEquals(output.jobs().get(0), Job.create("hudson.model.FreeStyleProject", "JobInFolder", System.getProperty("test.jenkins.endpoint")+"/job/test-folder/job/test-folder-1/job/JobInFolder/", "notbuilt"));
     }
 
     @Test(dependsOnMethods = "testCreateJobInFolder")


### PR DESCRIPTION
This is a simple fix in the case a user configures a different value for the integration test jenkins server, which happened to me when the local host port 8080 was already busy.