### PR TITLE
Fix test inter-dependencies (flaky tests)

### DIFF
--- a/src/test/java/com/cdancy/jenkins/rest/features/JobsApiLiveTest.java
+++ b/src/test/java/com/cdancy/jenkins/rest/features/JobsApiLiveTest.java
@@ -48,7 +48,7 @@ public class JobsApiLiveTest extends BaseJenkinsApiLiveTest {
         assertTrue(success.value());
     }
 
-    @Test(dependsOnMethods = "testCreateJob")
+    @Test(dependsOnMethods = {"testCreateJob", "testCreateJobForEmptyAndNullParams"})
     public void testGetJobListFromRoot() {
         JobList output = api().jobList("");
         assertNotNull(output);
@@ -380,6 +380,7 @@ public class JobsApiLiveTest extends BaseJenkinsApiLiveTest {
         assertFalse(output.hasMoreData());
     }
 
+    @Test
     public void testCreateJobForEmptyAndNullParams() {
         String config = payloadFromResource("/freestyle-project-empty-and-null-params.xml");
         RequestStatus success = api().create(null, "JobForEmptyAndNullParams", config);
@@ -409,7 +410,7 @@ public class JobsApiLiveTest extends BaseJenkinsApiLiveTest {
         assertTrue(parameters.get(1).value().isEmpty());
     }
 
-    @Test(dependsOnMethods = "testGetBuildParametersOfJobForEmptyAndNullParams")
+    @Test(dependsOnMethods = { "testGetBuildParametersOfJobForEmptyAndNullParams", "testGetJobListFromRoot"})
     public void testDeleteJobForEmptyAndNullParams() {
         RequestStatus success = api().delete(null, "JobForEmptyAndNullParams");
         assertTrue(success.value());


### PR DESCRIPTION
This fix was difficult to figure out. Sometimes the tests ran in the "right" order and they would all pass. Sometimes whey would run in the "wrong" order and there would be a test failure.

After much reading of the code, I figured out the JobsApiLiveTtest tests needed a few more inter-dependencies to be declared.

* `testGetJobListFromRoot` expects 2 jobs to exist, which means both `testCreateJob` and `testCreateJobForEmptyAndNullParams` must run first.
* `testCreateJobForEmptyAndNullParams` was actually not declared as a test, so I added the `@Test` annotation
* `testDeleteJobForEmptyAndNullParams` deletes one of the tests accounted for in `testGetJobListFromRoot` so it must run after it.

These three fixes make the Live test stable.