### PR TITLE
Fix crumb issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,16 +53,28 @@ Setting the `endpoint` can be done with any of the following (searched in order)
 
 Setting the `credentials` can be done with any of the following (searched in order):
 
+- `jenkins.rest.api.token`
+- `jenkinsRestApiToken`
+- `JENKINS_REST_API_TOKEN`
 - `jenkins.rest.credentials`
 - `jenkinsRestCredentials`
 - `JENKINS_REST_CREDENTIALS`
 
 ## Credentials
 
-jenkins-rest credentials can take 1 of 2 forms:
+jenkins-rest credentials can take 1 of 3 forms:
 
-- Colon delimited username and password: __admin:password__ 
-- Base64 encoded username and password: __YWRtaW46cGFzc3dvcmQ=__ 
+- Colon delimited username and api token: __admin:apiToken__
+  - use `JenkinsClient.builder().apiToken("admin:apiToken")`
+- Colon delimited username and password: __admin:password__
+  - use `JenkinsClient.builder().credentials("admin:password")`
+- Base64 encoded username followed by password __YWRtaW46cGFzc3dvcmQ=__ or api token __YWRtaW46YXBpVG9rZW4=__
+  - use `JenkinsClient.builder().apiToken("YWRtaW46YXBpVG9rZW4=")`
+  - use `JenkinsClient.builder().credentials("YWRtaW46cGFzc3dvcmQ=")`
+
+The Jenkins crumb is automatically requested for the anonymous and the username:password authentication methods.
+It is not requested when you use the apiToken as it is not needed.
+For more details, see the [Cloudbees crumb documentation](https://support.cloudbees.com/hc/en-us/articles/219257077-CSRF-Protection-Explained).
 
 ## Examples
 
@@ -80,11 +92,16 @@ Running mock tests can be done like so:
 
 	./gradlew clean build mockTest
 	
-Running integration tests can be done like so (requires existing jenkins instance):
+Running integration tests require an existing jenkins instance which can be obtained with docker:
 
+        docker build -t jenkins-rest/jenkins src/main/docker
+        docker run -d --rm -p 8080:8080 --name jenkins-rest jenkins-rest/jenkins
 	./gradlew clean build integTest 
 
 ### Integration tests settings
+
+If you use the provided docker instance, there is no other preparation necessary.
+If you wish to run integration tests against your own Jenkins server, the requirements are outlined in the next section.
 
 #### Jenkins instance requirements
 
@@ -95,6 +112,7 @@ Running integration tests can be done like so (requires existing jenkins instanc
 - Plugins
   - [CloudBees Credentials](https://plugins.jenkins.io/cloudbees-credentials): otherwise an http 500 error occurs when accessing
 to http://127.0.0.1:8080/job/test-folder/job/test-folder-1/ `java.lang.NoClassDefFoundError: com/cloudbees/hudson/plugins/folder/properties/FolderCredentialsProvider`
+  - [CloudBees Folder](https://plugins.jenkins.io/cloudbees-folder) plugin installed
   - [OWASP Markup Formatter](https://plugins.jenkins.io/antisamy-markup-formatter) configured to use `Safe HTML`
   - [Configuration As Code](https://plugins.jenkins.io/configuration-as-code) plugin installed
 
@@ -103,7 +121,7 @@ This project provides instructions to setup a [pre-configured Docker container](
 #### Integration tests configuration
 
 - jenkins url and authentication method used by the tests are defined in the `gradle.properties` file
-- by default, tests use the `credentials` authentication but this can be changed to use the `token` authentication
+- by default, tests use the `apiToken` authentication but this can be changed to use the other authentication methods.
 
 
 #### Running integration tests from within your IDE

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Setting the `endpoint` can be done with any of the following (searched in order)
 - `jenkinsRestEndpoint`
 - `JENKINS_REST_ENDPOINT`
 
+When none is found, the endpoint is set to `http://localhost:8080`.
+
 Setting the `credentials` can be done with any of the following (searched in order):
 
 - `jenkins.rest.api.token`
@@ -59,6 +61,8 @@ Setting the `credentials` can be done with any of the following (searched in ord
 - `jenkins.rest.credentials`
 - `jenkinsRestCredentials`
 - `JENKINS_REST_CREDENTIALS`
+
+When none is found, no authentication is used (anonymous).
 
 ## Credentials
 
@@ -69,12 +73,15 @@ jenkins-rest credentials can take 1 of 3 forms:
 - Colon delimited username and password: __admin:password__
   - use `JenkinsClient.builder().credentials("admin:password")`
 - Base64 encoded username followed by password __YWRtaW46cGFzc3dvcmQ=__ or api token __YWRtaW46YXBpVG9rZW4=__
-  - use `JenkinsClient.builder().apiToken("YWRtaW46YXBpVG9rZW4=")`
   - use `JenkinsClient.builder().credentials("YWRtaW46cGFzc3dvcmQ=")`
+  - use `JenkinsClient.builder().apiToken("YWRtaW46YXBpVG9rZW4=")`
 
-The Jenkins crumb is automatically requested for the anonymous and the username:password authentication methods.
-It is not requested when you use the apiToken as it is not needed.
-For more details, see the [Cloudbees crumb documentation](https://support.cloudbees.com/hc/en-us/articles/219257077-CSRF-Protection-Explained).
+The Jenkins crumb is automatically requested when POSTing using the anonymous and the username:password authentication methods.
+It is not requested when you use the apiToken as it is not needed in this case.
+For more details, see
+
+* [CSRF Protection on jenkins.io](https://www.jenkins.io/doc/book/security/csrf-protection/)
+* [Cloudbees crumb documentation](https://support.cloudbees.com/hc/en-us/articles/219257077-CSRF-Protection-Explained).
 
 ## Examples
 
@@ -107,6 +114,7 @@ If you wish to run integration tests against your own Jenkins server, the requir
 
 - a running instance accessible on http://127.0.0.1:8080 (can be changed in the gradle.properties file)
 - Jenkins security
+  - Authorization: Anyone can do anything (to be able to test the crumb with the anonymous account)
   - an `admin` user (credentials used by the tests can be changed in the gradle.properties file) with `ADMIN` role (required as the tests install plugins)
   - [CSRF protection enabled](https://wiki.jenkins.io/display/JENKINS/CSRF+Protection). Not mandatory but [recommended by the Jenkins documentation](https://jenkins.io/doc/book/system-administration/security/#protect-users-of-jenkins-from-other-threats). The lib supports Jenkins instances with our without this protection (see #14)
 - Plugins
@@ -115,20 +123,19 @@ to http://127.0.0.1:8080/job/test-folder/job/test-folder-1/ `java.lang.NoClassDe
   - [CloudBees Folder](https://plugins.jenkins.io/cloudbees-folder) plugin installed
   - [OWASP Markup Formatter](https://plugins.jenkins.io/antisamy-markup-formatter) configured to use `Safe HTML`
   - [Configuration As Code](https://plugins.jenkins.io/configuration-as-code) plugin installed
+- No Jenkins Jobs configured, no folder. The instance must be empty.
 
 This project provides instructions to setup a [pre-configured Docker container](src/main/docker/README.md)
 
 #### Integration tests configuration
 
 - jenkins url and authentication method used by the tests are defined in the `gradle.properties` file
-- by default, tests use the `apiToken` authentication but this can be changed to use the other authentication methods.
-
+- by default, tests use the `credentials` (username:password) authentication method but this can be changed to use the API Token. See the `gradle.properties` file.
 
 #### Running integration tests from within your IDE
 
-- the `integTest` gradle tasks set various System Properties
+- the `integTest` gradle task sets various System Properties
 - if you don't want to use gradle as tests runner in your IDE, configure the tests with the same kind of System Properties
-
 
 
 # Additional Resources

--- a/build.gradle
+++ b/build.gradle
@@ -89,21 +89,15 @@ task integTest(type: Test, dependsOn: mockTest) {
         showStandardStreams = true
         events 'started', 'passed', 'failed'
     }
-    def authentication = [:]
-    def possibleAuth = project.findProperty('testJenkinsRestApiToken')
-    if (possibleAuth) {
-        authentication['test.jenkins.rest.api.token'] = possibleAuth
-    } else {
-        possibleAuth = project.findProperty('testJenkinsRestCredentials')
-        if (possibleAuth) {
-            authentication['test.jenkins.rest.credentials'] = possibleAuth
-        } else {
-            logger.quiet 'No authentication parameters found. Assuming anonymous...'
-        }
+
+    def possibleUsernameApiToken = project.findProperty("testJenkinsUsernameApiToken")
+    def usernameApiToken = [:]
+    if (possibleUsernameApiToken) {
+        usernameApiToken["test.jenkins.usernameApiToken"] = possibleUsernameApiToken
     }
 
-    // property 'test.bitbucket.endpoint' needs to be
-    // hard-coded in for jclouds test framework
-    systemProperties = ["test.jenkins.endpoint" : "${testJenkinsRestEndpoint}",
-                        "test.jenkins.basedir" : "${buildDir}/integ-projects"] << authentication
+    systemProperties = [
+        "test.jenkins.endpoint" : testJenkinsRestEndpoint,
+        "test.jenkins.usernamePassword" : testJenkinsUsernamePassword
+    ] << usernameApiToken
 }

--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,8 @@ tasks.withType(JavaCompile) {
 }
 
 task mockTest(type: Test) {
+    group = "Verification"
+    description = "Mock tests"
     useTestNG()
     include '**/**MockTest*'
     maxParallelForks = 2
@@ -70,6 +72,8 @@ task mockTest(type: Test) {
 }
 
 task integTest(type: Test, dependsOn: mockTest) {
+    group = "Verification"
+    description = "Integration tests - Jenkins must be running. See the README."
     doFirst {
         def integProjectDir = project.file("${buildDir}/integ-projects")
         if (!integProjectDir.exists()) {
@@ -86,13 +90,13 @@ task integTest(type: Test, dependsOn: mockTest) {
         events 'started', 'passed', 'failed'
     }
     def authentication = [:]
-    def possibleAuth = project.findProperty('testJenkinsRestCredentials')
+    def possibleAuth = project.findProperty('testJenkinsRestApiToken')
     if (possibleAuth) {
-        authentication['test.jenkins.rest.credentials'] = possibleAuth
+        authentication['test.jenkins.rest.api.token'] = possibleAuth
     } else {
-        possibleAuth = project.findProperty('testJenkinsRestToken')
+        possibleAuth = project.findProperty('testJenkinsRestCredentials')
         if (possibleAuth) {
-            authentication['test.jenkins.rest.token'] = possibleAuth
+            authentication['test.jenkins.rest.credentials'] = possibleAuth
         } else {
             logger.quiet 'No authentication parameters found. Assuming anonymous...'
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,8 +9,12 @@ snapshotRepository = libs-snapshot-local
 releaseRepository = libs-release-local
 
 testJenkinsRestEndpoint = http://127.0.0.1:8080
-testJenkinsRestCredentials = admin:admin
-#testJenkinsRestToken
+testJenkinsUsernamePassword = admin:admin
+
+# Next line is optional.
+# Use it if you want to provide your own account with a pre-existing API Token,
+# instead of letting the test generate its own API Token.
+#testJenkinsUsernameApiToken = "admin:fixme"
 
 githubUsername=fixme
 githubPassword=fixme

--- a/src/main/docker/init.groovy.d/Security.groovy
+++ b/src/main/docker/init.groovy.d/Security.groovy
@@ -25,10 +25,6 @@ instance.setCrumbIssuer(new DefaultCrumbIssuer(true))
 def jenkinsRealm = new HudsonPrivateSecurityRealm(false)
 jenkinsRealm.createAccount('admin', 'admin')
 instance.setSecurityRealm(jenkinsRealm)
-def strategy = new FullControlOnceLoggedInAuthorizationStrategy()
-strategy.setAllowAnonymousRead(true)
-instance.setAuthorizationStrategy(strategy)
-
 
 // =====================================================================================================================
 // Save everything

--- a/src/main/java/com/cdancy/jenkins/rest/JenkinsApi.java
+++ b/src/main/java/com/cdancy/jenkins/rest/JenkinsApi.java
@@ -28,6 +28,7 @@ import com.cdancy.jenkins.rest.features.PluginManagerApi;
 import com.cdancy.jenkins.rest.features.QueueApi;
 import com.cdancy.jenkins.rest.features.StatisticsApi;
 import com.cdancy.jenkins.rest.features.SystemApi;
+import com.cdancy.jenkins.rest.features.UserApi;
 
 public interface JenkinsApi extends Closeable {
 
@@ -51,4 +52,7 @@ public interface JenkinsApi extends Closeable {
 
     @Delegate
     ConfigurationAsCodeApi configurationAsCodeApi();
+
+    @Delegate
+    UserApi userApi();
 }

--- a/src/main/java/com/cdancy/jenkins/rest/JenkinsAuthentication.java
+++ b/src/main/java/com/cdancy/jenkins/rest/JenkinsAuthentication.java
@@ -20,7 +20,7 @@ package com.cdancy.jenkins.rest;
 import static com.google.common.io.BaseEncoding.base64;
 
 import com.cdancy.jenkins.rest.auth.AuthenticationType;
-import com.cdancy.jenkins.rest.exception.UndetectableCredentialTypeException;
+import com.cdancy.jenkins.rest.exception.UndetectableIdentityException;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
@@ -121,7 +121,7 @@ public class JenkinsAuthentication extends Credentials {
                 decoded = credentialString;
             }
             if (!decoded.contains(":")) {
-                throw new UndetectableCredentialTypeException("Unable to detect the type of credential being used from '" + credentialString + "'. Supported types are a user:password, or a user:apiToken, or their base64 encoded value.");
+                throw new UndetectableIdentityException("Unable to detect the identity being used in '" + credentialString + "'. Supported types are a user:password, or a user:apiToken, or their base64 encoded value.");
             }
             if (decoded.equals(":")) {
                 return "";

--- a/src/main/java/com/cdancy/jenkins/rest/JenkinsAuthentication.java
+++ b/src/main/java/com/cdancy/jenkins/rest/JenkinsAuthentication.java
@@ -36,10 +36,11 @@ public class JenkinsAuthentication extends Credentials {
      * Create instance of JenkinsAuthentication
      * 
      * @param authValue value to use for authentication type HTTP header.
-     * @param authType authentication type (e.g. Basic, Bearer, Anonymous).
+     * @param authType authentication type (e.g. UsernamePassword, ApiToken, Anonymous).
      */
     private JenkinsAuthentication(final String authValue, final AuthenticationType authType) {
-        super(null, authType == AuthenticationType.Basic && authValue.contains(":")
+        //super(authValue != null ? (authValue.contains(":") ? authValue.split(":")[0] : null) : null, (authType == AuthenticationType.UsernamePassword || authType == AuthenticationType.ApiToken) && authValue.contains(":")
+        super(null, (authType == AuthenticationType.UsernamePassword || authType == AuthenticationType.ApiToken) && authValue.contains(":")
                 ? base64().encode(authValue.getBytes())
                 : authValue);
         this.authType = authType;    
@@ -64,26 +65,26 @@ public class JenkinsAuthentication extends Credentials {
         private AuthenticationType authType;
 
         /**
-         * Set 'Basic' credentials.
+         * Set 'UsernamePassword' credentials.
          * 
-         * @param basicCredentials value to use for 'Basic' credentials.
+         * @param usernamePassword value to use for 'UsernamePassword' credentials.
          * @return this Builder.
          */
-        public Builder credentials(final String basicCredentials) {
-            this.authValue = Objects.requireNonNull(basicCredentials);
-            this.authType = AuthenticationType.Basic;
+        public Builder credentials(final String usernamePassword) {
+            this.authValue = Objects.requireNonNull(usernamePassword);
+            this.authType = AuthenticationType.UsernamePassword;
             return this;
         }
 
         /**
-         * Set 'Bearer' credentials.
-         * 
-         * @param tokenCredentials value to use for 'Bearer' credentials.
+         * Set 'ApiToken' credentials.
+         *
+         * @param apiTokenCredentials value to use for 'ApiToken' credentials.
          * @return this Builder.
          */
-        public Builder token(final String tokenCredentials) {
-            this.authValue = Objects.requireNonNull(tokenCredentials);
-            this.authType = AuthenticationType.Bearer;
+        public Builder apiToken(final String apiTokenCredentials) {
+            this.authValue = Objects.requireNonNull(apiTokenCredentials);
+            this.authType = AuthenticationType.ApiToken;
             return this;
         }
 

--- a/src/main/java/com/cdancy/jenkins/rest/JenkinsAuthentication.java
+++ b/src/main/java/com/cdancy/jenkins/rest/JenkinsAuthentication.java
@@ -20,37 +20,48 @@ package com.cdancy.jenkins.rest;
 import static com.google.common.io.BaseEncoding.base64;
 
 import com.cdancy.jenkins.rest.auth.AuthenticationType;
+import com.cdancy.jenkins.rest.exception.UndetectableCredentialTypeException;
+
+import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 
 import org.jclouds.domain.Credentials;
 import org.jclouds.javax.annotation.Nullable;
 
 /**
- * Credentials instance for Jenkins authentication. 
+ * Credentials instance for Jenkins authentication.
  */
 public class JenkinsAuthentication extends Credentials {
 
     private final AuthenticationType authType;
 
     /**
-     * Create instance of JenkinsAuthentication
-     * 
-     * @param authValue value to use for authentication type HTTP header.
-     * @param authType authentication type (e.g. UsernamePassword, ApiToken, Anonymous).
+     * Create instance of JenkinsAuthentication.
+     *
+     * @param identity the identity of the credential, this would be the username for the password or the api token or the base64 encoded value.
+     * @param credential the username:password, or the username:apiToken, or their base64 encoded value. This is base64 encoded before being stored.
+     * @param authType authentication type (e.g. UsernamePassword, UsernameApiToken, Anonymous).
      */
-    private JenkinsAuthentication(final String authValue, final AuthenticationType authType) {
-        //super(authValue != null ? (authValue.contains(":") ? authValue.split(":")[0] : null) : null, (authType == AuthenticationType.UsernamePassword || authType == AuthenticationType.ApiToken) && authValue.contains(":")
-        super(null, (authType == AuthenticationType.UsernamePassword || authType == AuthenticationType.ApiToken) && authValue.contains(":")
-                ? base64().encode(authValue.getBytes())
-                : authValue);
-        this.authType = authType;    
+    private JenkinsAuthentication(final String identity, final String credential, final AuthenticationType authType) {
+        super(identity,  credential.contains(":") ? base64().encode(credential.getBytes()) : credential);
+        this.authType = authType;
     }
 
+    /**
+     * Return the base64 encoded value of the credential.
+     *
+     * @return the base 64 encoded authentication value.
+     */
     @Nullable
     public String authValue() {
         return this.credential;
     }
 
+    /**
+     * Return the authentication type.
+     *
+     * @return the authentication type.
+     */
     public AuthenticationType authType() {
         return authType;
     }
@@ -61,42 +72,70 @@ public class JenkinsAuthentication extends Credentials {
 
     public static class Builder {
 
-        private String authValue;
-        private AuthenticationType authType;
+        private String identity = "anonymous";
+        private String credential = identity + ":";
+        private AuthenticationType authType = AuthenticationType.Anonymous;
 
         /**
          * Set 'UsernamePassword' credentials.
-         * 
-         * @param usernamePassword value to use for 'UsernamePassword' credentials.
+         *
+         * @param usernamePassword value to use for 'UsernamePassword' credentials. It can be the {@code username:password} in clear text or its base64 encoded value.
          * @return this Builder.
          */
         public Builder credentials(final String usernamePassword) {
-            this.authValue = Objects.requireNonNull(usernamePassword);
+            this.identity = Objects.requireNonNull(extractIdentity(usernamePassword));
+            this.credential = Objects.requireNonNull(usernamePassword);
             this.authType = AuthenticationType.UsernamePassword;
             return this;
         }
 
         /**
-         * Set 'ApiToken' credentials.
+         * Set 'UsernameApiToken' credentials.
          *
-         * @param apiTokenCredentials value to use for 'ApiToken' credentials.
+         * @param apiTokenCredentials value to use for 'ApiToken' credentials. It can be the {@code username:apiToken} in clear text or its base64 encoded value.
          * @return this Builder.
          */
         public Builder apiToken(final String apiTokenCredentials) {
-            this.authValue = Objects.requireNonNull(apiTokenCredentials);
-            this.authType = AuthenticationType.ApiToken;
+            this.identity = Objects.requireNonNull(extractIdentity(apiTokenCredentials));
+            this.credential = Objects.requireNonNull(apiTokenCredentials);
+            this.authType = AuthenticationType.UsernameApiToken;
             return this;
         }
 
         /**
+         * Extract the identity from the credential.
+         *
+         * The credential is entered by the user in one of two forms:
+         * <ol>
+         *  <li>Colon separated form: <code>username:password</code> or <code>username:password</code>
+         *  <li>Base64 encoded of the colon separated form.
+         * </ol>
+         * Either way the identity is the username, and it can be extracted directly or by decoding.
+         */
+        private String extractIdentity(final String credentialString) {
+            String maybeEncoded = credentialString;
+            String decoded;
+            if (!maybeEncoded.contains(":")) {
+                decoded = new String(base64().decode(credentialString),StandardCharsets.UTF_8);
+            } else {
+                decoded = credentialString;
+            }
+            if (!decoded.contains(":")) {
+                throw new UndetectableCredentialTypeException("Unable to detect the type of credential being used from '" + credentialString + "'. Supported types are a user:password, or a user:apiToken, or their base64 encoded value.");
+            }
+            if (decoded.equals(":")) {
+                return "";
+            }
+            return decoded.split(":")[0];
+        }
+
+       /**
          * Build and instance of JenkinsCredentials.
-         * 
+         *
          * @return instance of JenkinsCredentials.
          */
         public JenkinsAuthentication build() {
-            return new JenkinsAuthentication(authValue, authType != null
-                    ? authType
-                    : AuthenticationType.Anonymous);
+            return new JenkinsAuthentication(identity, credential, authType);
         }
     }
 }

--- a/src/main/java/com/cdancy/jenkins/rest/JenkinsClient.java
+++ b/src/main/java/com/cdancy/jenkins/rest/JenkinsClient.java
@@ -168,14 +168,15 @@ public final class JenkinsClient implements Closeable {
         }
 
         /**
-         * Optional token to use for authentication.
+         * Optional Api token to use for authentication.
+         * This is not a Bearer token, hence the name apiToken.
          *
-         * @param token authentication token.
+         * @param apiToken authentication token.
          * @return this Builder.
          */
-        public Builder token(final String token) {
+        public Builder apiToken(final String apiToken) {
             authBuilder = JenkinsAuthentication.builder()
-                    .token(token);
+                    .apiToken(apiToken);
             return this;
         }
 

--- a/src/main/java/com/cdancy/jenkins/rest/JenkinsConstants.java
+++ b/src/main/java/com/cdancy/jenkins/rest/JenkinsConstants.java
@@ -28,8 +28,8 @@ public class JenkinsConstants {
     public static final String CREDENTIALS_SYSTEM_PROPERTY = "jenkins.rest.credentials";
     public static final String CREDENTIALS_ENVIRONMENT_VARIABLE = CREDENTIALS_SYSTEM_PROPERTY.replaceAll("\\.", "_").toUpperCase();
 
-    public static final String TOKEN_SYSTEM_PROPERTY = "jenkins.rest.token";
-    public static final String TOKEN_ENVIRONMENT_VARIABLE = TOKEN_SYSTEM_PROPERTY.replaceAll("\\.", "_").toUpperCase();
+    public static final String API_TOKEN_SYSTEM_PROPERTY = "jenkins.rest.api.token";
+    public static final String API_TOKEN_ENVIRONMENT_VARIABLE = API_TOKEN_SYSTEM_PROPERTY.replaceAll("\\.", "_").toUpperCase();
 
     public static final String DEFAULT_ENDPOINT = "http://127.0.0.1:7990";
 

--- a/src/main/java/com/cdancy/jenkins/rest/JenkinsConstants.java
+++ b/src/main/java/com/cdancy/jenkins/rest/JenkinsConstants.java
@@ -41,6 +41,8 @@ public class JenkinsConstants {
 
     public static final String OPTIONAL_FOLDER_PATH_PARAM = "optionalFolderPath";
 
+    public static final String USER_IN_USER_API = "user";
+
     public static final String JENKINS_COOKIES_JSESSIONID = "JSESSIONID";
 
     protected JenkinsConstants() {

--- a/src/main/java/com/cdancy/jenkins/rest/JenkinsUtils.java
+++ b/src/main/java/com/cdancy/jenkins/rest/JenkinsUtils.java
@@ -161,7 +161,7 @@ public class JenkinsUtils {
     /**
      * Find credentials (ApiToken, UsernamePassword, or Anonymous) from system/environment.
      *
-     * @return BitbucketCredentials
+     * @return JenkinsAuthentication
      */
     public static JenkinsAuthentication inferAuthentication() {
 

--- a/src/main/java/com/cdancy/jenkins/rest/auth/AuthenticationType.java
+++ b/src/main/java/com/cdancy/jenkins/rest/auth/AuthenticationType.java
@@ -23,7 +23,7 @@ package com.cdancy.jenkins.rest.auth;
 public enum AuthenticationType {
 
     UsernamePassword("UsernamePassword", "Basic"),
-    ApiToken("ApiToken", "Basic"),
+    UsernameApiToken("UsernameApiToken", "Basic"),
     Anonymous("Anonymous", "");
 
     private final String authName;

--- a/src/main/java/com/cdancy/jenkins/rest/domain/user/ApiToken.java
+++ b/src/main/java/com/cdancy/jenkins/rest/domain/user/ApiToken.java
@@ -14,32 +14,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package com.cdancy.jenkins.rest.domain.user;
 
-package com.cdancy.jenkins.rest.auth;
+import com.google.auto.value.AutoValue;
+import org.jclouds.json.SerializedNames;
 
-/**
- * Supported Authentication Types for Jenkins.
- */
-public enum AuthenticationType {
+@AutoValue
+public abstract class ApiToken {
 
-    UsernamePassword("UsernamePassword", "Basic"),
-    ApiToken("ApiToken", "Basic"),
-    Anonymous("Anonymous", "");
+    public abstract String status();
 
-    private final String authName;
-    private final String authScheme;
+    public abstract ApiTokenData data();
 
-    private AuthenticationType(final String authName, final String authScheme) {
-        this.authName = authName;
-        this.authScheme = authScheme;
+    ApiToken() {
     }
 
-    public String getAuthScheme() {
-        return authScheme;
-    }
-
-    @Override
-    public String toString() {
-        return authName;
+    @SerializedNames({"status", "data"})
+    public static ApiToken create(final String status, final ApiTokenData data) {
+        return new AutoValue_ApiToken(status, data);
     }
 }

--- a/src/main/java/com/cdancy/jenkins/rest/domain/user/ApiTokenData.java
+++ b/src/main/java/com/cdancy/jenkins/rest/domain/user/ApiTokenData.java
@@ -14,32 +14,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package com.cdancy.jenkins.rest.domain.user;
 
-package com.cdancy.jenkins.rest.auth;
+import com.google.auto.value.AutoValue;
+import org.jclouds.json.SerializedNames;
 
-/**
- * Supported Authentication Types for Jenkins.
- */
-public enum AuthenticationType {
+@AutoValue
+public abstract class ApiTokenData {
 
-    UsernamePassword("UsernamePassword", "Basic"),
-    ApiToken("ApiToken", "Basic"),
-    Anonymous("Anonymous", "");
+    public abstract String tokenName();
+    public abstract String tokenUuid();
+    public abstract String tokenValue();
 
-    private final String authName;
-    private final String authScheme;
-
-    private AuthenticationType(final String authName, final String authScheme) {
-        this.authName = authName;
-        this.authScheme = authScheme;
+    ApiTokenData() {
     }
 
-    public String getAuthScheme() {
-        return authScheme;
-    }
-
-    @Override
-    public String toString() {
-        return authName;
+    @SerializedNames({"tokenName", "tokenUuid", "tokenValue"})
+    public static ApiTokenData create(final String tokenName, final String tokenUuid, final String tokenValue) {
+        return new AutoValue_ApiTokenData(tokenName, tokenUuid, tokenValue);
     }
 }

--- a/src/main/java/com/cdancy/jenkins/rest/domain/user/Property.java
+++ b/src/main/java/com/cdancy/jenkins/rest/domain/user/Property.java
@@ -1,0 +1,18 @@
+package com.cdancy.jenkins.rest.domain.user;
+
+import com.google.auto.value.AutoValue;
+import org.jclouds.json.SerializedNames;
+
+@AutoValue
+public abstract class Property {
+
+    public abstract String clazz();
+
+    Property() {
+    }
+
+    @SerializedNames({"_class"})
+    public static Property create(final String clazz) {
+        return new AutoValue_Property(clazz);
+    }
+}

--- a/src/main/java/com/cdancy/jenkins/rest/domain/user/User.java
+++ b/src/main/java/com/cdancy/jenkins/rest/domain/user/User.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.cdancy.jenkins.rest.domain.user;
+
+import java.util.List;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
+import org.jclouds.javax.annotation.Nullable;
+import org.jclouds.json.SerializedNames;
+
+@AutoValue
+public abstract class User {
+
+    public abstract String absoluteUrl();
+
+    @Nullable
+    public abstract String description();
+
+    public abstract String fullName();
+
+    public abstract String id();
+
+    // TODO: Find a way to support properties, which is a list of different extensions of a base class
+    // public abstract List<Property> properties();
+
+    User() {
+    }
+
+    @SerializedNames({"absoluteUrl", "description", "fullName", "id"})
+    public static User create(final String absoluteUrl, final String description, final String fullName, final String id) {
+        return new AutoValue_User(absoluteUrl, description, fullName, id);
+    }
+}

--- a/src/main/java/com/cdancy/jenkins/rest/exception/UndetectableCredentialTypeException.java
+++ b/src/main/java/com/cdancy/jenkins/rest/exception/UndetectableCredentialTypeException.java
@@ -18,29 +18,31 @@
 package com.cdancy.jenkins.rest.exception;
 
 /**
- * The request entity has a Content-Type that the server does not support.
- * Some Jenkins REST API accept application/json format, but
- * check the individual resource documentation for more details. Additionally,
- * double-check that you are setting the Content-Type header correctly on your
- * request (e.g. using -H "Content-Type: application/json" in cURL).
+ * The credential being passed cannot be processed.
+ *
+ * A valid credential is either
+ * <ol>
+ *     <li>a colon separated identity and password or token (tuple of )identity:password or identity:token); or</li>
+ *     <li>the base64 encoded form of identity:password or identity:token</li>
+ * </ol>
+ * When the credential does not contain a colon, an attempt is made at decoding it to extract the identity.
+ * When this fails, this exception is thrown.
+ *
  */
-public class UnsupportedMediaTypeException extends RuntimeException {
-
+public class UndetectableCredentialTypeException extends RuntimeException {
     private static final long serialVersionUID = 1L;
 
-    public UnsupportedMediaTypeException() {
-      super();
+    public UndetectableCredentialTypeException() { super(); }
+
+    public UndetectableCredentialTypeException(final String arg0, final Throwable arg1) {
+            super(arg0, arg1);
     }
 
-    public UnsupportedMediaTypeException(final String arg0, final Throwable arg1) {
-      super(arg0, arg1);
+    public UndetectableCredentialTypeException(final String arg0) {
+            super(arg0);
     }
 
-    public UnsupportedMediaTypeException(final String arg0) {
-      super(arg0);
-    }
-
-    public UnsupportedMediaTypeException(final Throwable arg0) {
-      super(arg0);
+    public UndetectableCredentialTypeException(final Throwable arg0) {
+        super(arg0);
     }
 }

--- a/src/main/java/com/cdancy/jenkins/rest/exception/UndetectableIdentityException.java
+++ b/src/main/java/com/cdancy/jenkins/rest/exception/UndetectableIdentityException.java
@@ -29,20 +29,20 @@ package com.cdancy.jenkins.rest.exception;
  * When this fails, this exception is thrown.
  *
  */
-public class UndetectableCredentialTypeException extends RuntimeException {
+public class UndetectableIdentityException extends RuntimeException {
     private static final long serialVersionUID = 1L;
 
-    public UndetectableCredentialTypeException() { super(); }
+    public UndetectableIdentityException() { super(); }
 
-    public UndetectableCredentialTypeException(final String arg0, final Throwable arg1) {
+    public UndetectableIdentityException(final String arg0, final Throwable arg1) {
             super(arg0, arg1);
     }
 
-    public UndetectableCredentialTypeException(final String arg0) {
+    public UndetectableIdentityException(final String arg0) {
             super(arg0);
     }
 
-    public UndetectableCredentialTypeException(final Throwable arg0) {
+    public UndetectableIdentityException(final Throwable arg0) {
         super(arg0);
     }
 }

--- a/src/main/java/com/cdancy/jenkins/rest/features/UserApi.java
+++ b/src/main/java/com/cdancy/jenkins/rest/features/UserApi.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cdancy.jenkins.rest.features;
+
+import javax.inject.Named;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.jclouds.Fallbacks;
+import org.jclouds.rest.annotations.Fallback;
+import org.jclouds.rest.annotations.Payload;
+import org.jclouds.rest.annotations.PayloadParam;
+import org.jclouds.rest.annotations.RequestFilters;
+
+import com.cdancy.jenkins.rest.domain.user.ApiToken;
+import com.cdancy.jenkins.rest.domain.user.User;
+import com.cdancy.jenkins.rest.domain.common.RequestStatus;
+import com.cdancy.jenkins.rest.fallbacks.JenkinsFallbacks;
+import com.cdancy.jenkins.rest.filters.JenkinsAuthenticationFilter;
+import com.cdancy.jenkins.rest.filters.JenkinsUserInjectionFilter;
+import com.cdancy.jenkins.rest.parsers.RequestStatusParser;
+import org.jclouds.rest.annotations.ResponseParser;
+
+/**
+ * The UserApi.
+ *
+ * Implements some of the User Rest Api defined in Jenkins.
+ * For the User Api, see <a href="https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/hudson/model/User.java">User.java</a>
+ * For the Api Token, see <a href="https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/jenkins/security/ApiTokenProperty.java">ApiTokenProperty.java</a>.
+ */
+@RequestFilters({JenkinsAuthenticationFilter.class, JenkinsUserInjectionFilter.class})
+@Path("/user")
+public interface UserApi {
+
+    @Named("user:get")
+    @Path("/{user}/api/json")
+    @Fallback(Fallbacks.NullOnNotFoundOr404.class)
+    @Consumes(MediaType.APPLICATION_JSON)
+    @GET
+    User get();
+
+    @Named("user:generateNewToken")
+    @Path("/{user}/descriptorByName/jenkins.security.ApiTokenProperty/generateNewToken")
+    @Fallback(Fallbacks.NullOnNotFoundOr404.class)
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_FORM_URLENCODED)
+    @Payload("newTokenName={tokenName}")
+    @POST
+    ApiToken generateNewToken(@PayloadParam(value = "tokenName") String tokenName);
+
+    @Named("user:revoke")
+    @Path("/{user}/descriptorByName/jenkins.security.ApiTokenProperty/revoke")
+    @Fallback(JenkinsFallbacks.RequestStatusOnError.class)
+    @ResponseParser(RequestStatusParser.class)
+    @Produces(MediaType.APPLICATION_FORM_URLENCODED)
+    @Payload("tokenUuid={tokenUuid}")
+    @POST
+    RequestStatus revoke(@PayloadParam(value = "tokenUuid") String tokenUuid);
+}

--- a/src/main/java/com/cdancy/jenkins/rest/filters/JenkinsNoCrumbAuthenticationFilter.java
+++ b/src/main/java/com/cdancy/jenkins/rest/filters/JenkinsNoCrumbAuthenticationFilter.java
@@ -43,7 +43,7 @@ public class JenkinsNoCrumbAuthenticationFilter implements HttpRequestFilter {
         if (creds.authType() == AuthenticationType.Anonymous) {
             return request;
         } else {
-            final String authHeader = creds.authType() + " " + creds.authValue();
+            final String authHeader = creds.authType().getAuthScheme() + " " + creds.authValue();
             return request.toBuilder().addHeader(HttpHeaders.AUTHORIZATION, authHeader).build();
         }
     }

--- a/src/main/java/com/cdancy/jenkins/rest/filters/JenkinsUserInjectionFilter.java
+++ b/src/main/java/com/cdancy/jenkins/rest/filters/JenkinsUserInjectionFilter.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cdancy.jenkins.rest.filters;
+
+import org.jclouds.http.HttpException;
+import org.jclouds.http.HttpRequest;
+import org.jclouds.http.HttpRequestFilter;
+
+import com.cdancy.jenkins.rest.JenkinsAuthentication;
+import static com.cdancy.jenkins.rest.JenkinsConstants.USER_IN_USER_API;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+@Singleton
+public class JenkinsUserInjectionFilter implements HttpRequestFilter {
+
+    private static final String USER_PLACE_HOLDER = "%7B" + USER_IN_USER_API + "%7D";
+    private final JenkinsAuthentication creds;
+
+    @Inject
+    public JenkinsUserInjectionFilter(final JenkinsAuthentication creds) {
+        this.creds = creds;
+    }
+
+    @Override
+    public HttpRequest filter(final HttpRequest request) throws HttpException {
+        final String requestPath = request.getEndpoint().getRawPath().replaceAll(USER_PLACE_HOLDER, creds.identity);
+        return request.toBuilder().fromHttpRequest(request).replacePath(requestPath).build();
+    }
+}

--- a/src/test/java/com/cdancy/jenkins/rest/BaseJenkinsApiLiveTest.java
+++ b/src/test/java/com/cdancy/jenkins/rest/BaseJenkinsApiLiveTest.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.util.Properties;
 import java.util.UUID;
 
+import com.cdancy.jenkins.rest.auth.AuthenticationType;
 import com.cdancy.jenkins.rest.domain.queue.QueueItem;
 import com.cdancy.jenkins.rest.features.QueueApi;
 import org.jclouds.Constants;
@@ -37,7 +38,6 @@ import com.google.inject.Module;
 @Test(groups = "live")
 public class BaseJenkinsApiLiveTest extends BaseApiLiveTest<JenkinsApi> {
 
-    protected final String defaultBitbucketGroup = "stash-users";
     protected final JenkinsAuthentication jenkinsAuthentication;
 
     public BaseJenkinsApiLiveTest() {

--- a/src/test/java/com/cdancy/jenkins/rest/BaseJenkinsMockTest.java
+++ b/src/test/java/com/cdancy/jenkins/rest/BaseJenkinsMockTest.java
@@ -17,104 +17,27 @@
 
 package com.cdancy.jenkins.rest;
 
-import static org.jclouds.util.Strings2.toStringAndClose;
-
 import java.io.IOException;
-import java.net.URL;
 import java.util.Map;
-import java.util.Properties;
 
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 
-import org.jclouds.Constants;
-import org.jclouds.ContextBuilder;
-
-import com.cdancy.jenkins.rest.config.JenkinsAuthenticationModule;
-import com.cdancy.jenkins.rest.auth.AuthenticationType;
-
-import com.google.common.base.Charsets;
 import com.google.common.base.Functions;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.gson.JsonParser;
-import com.squareup.okhttp.mockwebserver.MockResponse;
 import com.squareup.okhttp.mockwebserver.MockWebServer;
 import com.squareup.okhttp.mockwebserver.RecordedRequest;
-import static com.google.common.io.BaseEncoding.base64;
-import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNull;
-
-import org.jclouds.logging.slf4j.config.SLF4JLoggingModule;
 
 /**
  * Base class for all Jenkins mock tests.
  */
-public class BaseJenkinsMockTest {
+public class BaseJenkinsMockTest extends BaseJenkinsTest {
 
-    public static final String USERNAME_PASSWORD = "user:passwd";
-    public static final String USERNAME_APITOKEN = "user:token";
-
-    protected final String provider;
     private final JsonParser parser = new JsonParser();
-
-    public BaseJenkinsMockTest() {
-        provider = "jenkins";
-    }
-
-    /**
-     * Create API from passed URL.
-     * 
-     * @param url endpoint of instance.
-     * @return instance of JenkinsApi.
-     */
-    public JenkinsApi api(final URL url) {
-        return api(url, AuthenticationType.ApiToken);
-    }
-
-    /**
-     * Create API from passed URL and passed authentication type.
-     *
-     * @param url endpoint of instance.
-     * @param authType authentication type.
-     */
-    public JenkinsApi api(final URL url, final AuthenticationType authType) {
-        final JenkinsAuthentication creds = creds(authType);
-        final JenkinsAuthenticationModule credsModule = new JenkinsAuthenticationModule(creds);
-        return ContextBuilder.newBuilder(provider)
-                .endpoint(url.toString())
-                .overrides(setupProperties())
-                .modules(Lists.newArrayList(credsModule, new SLF4JLoggingModule()))
-                .buildApi(JenkinsApi.class);
-    }
-
-    /**
-     * Create the Jenkins Authentication instance.
-     *
-     * @param authType authentication type. Falls back to anonymous when null.
-     * @return an authenticaition instance.
-     */
-    public JenkinsAuthentication creds(final AuthenticationType authType) {
-        final JenkinsAuthentication.Builder authBuilder = JenkinsAuthentication.builder();
-        if (authType == AuthenticationType.UsernamePassword) {
-            authBuilder.credentials(USERNAME_PASSWORD);
-        } else if (authType == AuthenticationType.ApiToken) {
-            authBuilder.apiToken(USERNAME_APITOKEN);
-        }
-        // Anonymous authentication is the default when not specified
-        return authBuilder.build();
-    }
-
-    protected Properties setupProperties() {
-        final Properties properties = new Properties();
-        properties.setProperty(Constants.PROPERTY_MAX_RETRIES, "0");
-        properties.setProperty(Constants.PROPERTY_CONNECTION_TIMEOUT, "1");
-        return properties;
-    }
 
     /**
      * Create a MockWebServer with an initial bread-crumb response.
@@ -127,21 +50,6 @@ public class BaseJenkinsMockTest {
         final MockWebServer server = new MockWebServer();
         server.start();
         return server;
-    }
-
-    /**
-     * Get the String representation of some resource to be used as payload.
-     *
-     * @param resource
-     *            String representation of a given resource
-     * @return payload in String form
-     */
-    public String payloadFromResource(final String resource) {
-        try {
-            return new String(toStringAndClose(getClass().getResourceAsStream(resource)).getBytes(Charsets.UTF_8));
-        } catch (IOException e) {
-            throw Throwables.propagate(e);
-        }
     }
 
     private static Map<String, String> extractParams(final String path) {
@@ -164,21 +72,21 @@ public class BaseJenkinsMockTest {
         return builder.build();
     }
 
-    protected RecordedRequest assertSent(final MockWebServer server, 
-            final String method, 
+    protected RecordedRequest assertSent(final MockWebServer server,
+            final String method,
             final String path) throws InterruptedException {
 
         return assertSent(server, method, path, ImmutableMap.<String, Void> of());
     }
 
-    protected RecordedRequest assertSent(final MockWebServer server, 
-            final String method, 
-            final String expectedPath, 
+    protected RecordedRequest assertSent(final MockWebServer server,
+            final String method,
+            final String expectedPath,
             final Map<String, ?> queryParams) throws InterruptedException {
 
         RecordedRequest request = server.takeRequest();
         assertThat(request.getMethod()).isEqualTo(method);
-        assertThat(request.getHeader(HttpHeaders.ACCEPT)).isEqualTo(APPLICATION_JSON);
+        assertThat(request.getHeader(HttpHeaders.ACCEPT)).isEqualTo(MediaType.APPLICATION_JSON);
 
         final String path = request.getPath();
         final String rawPath = path.contains("?") ? path.substring(0, path.indexOf('?')) : path;
@@ -190,16 +98,16 @@ public class BaseJenkinsMockTest {
         return request;
     }
 
-    protected RecordedRequest assertSentWithFormData(final MockWebServer server, 
-            final String method, 
-            final String path, 
+    protected RecordedRequest assertSentWithFormData(final MockWebServer server,
+            final String method,
+            final String path,
             final String body) throws InterruptedException {
 
         RecordedRequest request = server.takeRequest();
         assertThat(request.getMethod()).isEqualTo(method);
         assertThat(request.getPath()).isEqualTo(path);
         assertThat(request.getUtf8Body()).isEqualTo(body);
-        assertThat(request.getHeader(HttpHeaders.ACCEPT)).isEqualTo(APPLICATION_JSON);
+        assertThat(request.getHeader(HttpHeaders.ACCEPT)).isEqualTo(MediaType.APPLICATION_JSON);
         assertThat(request.getHeader(HttpHeaders.CONTENT_TYPE)).isEqualTo(MediaType.APPLICATION_FORM_URLENCODED);
         return request;
     }
@@ -247,20 +155,8 @@ public class BaseJenkinsMockTest {
 
     protected RecordedRequest assertSent(MockWebServer server, String method, String path, String json) throws InterruptedException {
         RecordedRequest request = server.takeRequest();
-        assertEquals(request.getHeader("Content-Type"), APPLICATION_JSON);
+        assertEquals(request.getHeader("Content-Type"), MediaType.APPLICATION_JSON);
         assertEquals(parser.parse(request.getUtf8Body()), parser.parse(json));
-        return request;
-    }
-
-    protected RecordedRequest assertSentAcceptAuth(MockWebServer server, String method, String path, String acceptType, AuthenticationType authType) throws InterruptedException {
-        RecordedRequest request = assertSentAccept(server, method, path, acceptType);
-        if (authType == AuthenticationType.UsernamePassword) {
-            assertEquals(request.getHeader("Authorization"), authType.getAuthScheme() + " " + base64().encode(USERNAME_PASSWORD.getBytes()));
-        } else if (authType == AuthenticationType.ApiToken) {
-            assertEquals(request.getHeader("Authorization"), authType.getAuthScheme() + " " + base64().encode(USERNAME_APITOKEN.getBytes()));
-        } else {
-            assertNull(request.getHeader("Authorization"));
-        }
         return request;
     }
 }

--- a/src/test/java/com/cdancy/jenkins/rest/BaseJenkinsTest.java
+++ b/src/test/java/com/cdancy/jenkins/rest/BaseJenkinsTest.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cdancy.jenkins.rest;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Properties;
+
+import org.jclouds.Constants;
+import org.jclouds.ContextBuilder;
+import org.jclouds.logging.slf4j.config.SLF4JLoggingModule;
+import static org.jclouds.util.Strings2.toStringAndClose;
+
+import com.cdancy.jenkins.rest.config.JenkinsAuthenticationModule;
+import com.cdancy.jenkins.rest.auth.AuthenticationType;
+
+import com.google.common.base.Charsets;
+import com.google.common.base.Throwables;
+import com.google.common.collect.Lists;
+
+/**
+ * Base class for Jenkins mock tests and some Live tests.
+ */
+public class BaseJenkinsTest {
+
+    // The test container has this admin user defined:
+    public static final String USERNAME_PASSWORD = "admin:admin";
+
+    // This token can only be used by mock test as real tokens can only be obtained from jenkins itself
+    public static final String USERNAME_APITOKEN = "user:token";
+
+    protected final String provider;
+
+    public BaseJenkinsTest() {
+        provider = "jenkins";
+    }
+
+    /**
+     * Create API from passed URL.
+     *
+     * The default authentication is the ApiToken, for it requires no crumb and simplifies mockTests expectations.
+     *
+     * @param url endpoint of instance.
+     * @return instance of JenkinsApi.
+     */
+    public JenkinsApi api(final URL url) {
+        return api(url, AuthenticationType.UsernameApiToken, USERNAME_APITOKEN);
+    }
+
+    /**
+     * Create API for Anonymous access using the passed URL.
+     *
+     * @param url endpoint of instance.
+     * @return instance of JenkinsApi.
+     */
+    public JenkinsApi anonymousAuthApi(final URL url) {
+        return api(url, AuthenticationType.Anonymous, AuthenticationType.Anonymous.name().toLowerCase());
+    }
+
+    /**
+     * Create API for the given authentication type and string.
+     *
+     * @param url the endpoint of the instance.
+     * @param authType the type of authentication.
+     * @param authString the string to use as the credential.
+     * @return instance of JenkinsApi.
+     */
+    public JenkinsApi api(final URL url, final AuthenticationType authType, final String authString) {
+        final JenkinsAuthentication creds = creds(authType, authString);
+        final JenkinsAuthenticationModule credsModule = new JenkinsAuthenticationModule(creds);
+        return ContextBuilder.newBuilder(provider)
+                .endpoint(url.toString())
+                .overrides(setupProperties())
+                .modules(Lists.newArrayList(credsModule, new SLF4JLoggingModule()))
+                .buildApi(JenkinsApi.class);
+    }
+    /**
+     * Create the Jenkins Authentication instance.
+     *
+     * @param authType authentication type. Falls back to anonymous when null.
+     * @param authString the authentication string to use (username:password, username:apiToken, or base64 encoded).
+     * @return an authentication instance.
+     */
+    public JenkinsAuthentication creds(final AuthenticationType authType, final String authString) {
+        final JenkinsAuthentication.Builder authBuilder = JenkinsAuthentication.builder();
+        if (authType == AuthenticationType.UsernamePassword) {
+            authBuilder.credentials(authString);
+        } else if (authType == AuthenticationType.UsernameApiToken) {
+            authBuilder.apiToken(authString);
+        }
+        // Anonymous authentication is the default when not specified
+        return authBuilder.build();
+    }
+
+    protected Properties setupProperties() {
+        final Properties properties = new Properties();
+        properties.setProperty(Constants.PROPERTY_MAX_RETRIES, "0");
+        properties.setProperty(Constants.PROPERTY_CONNECTION_TIMEOUT, "1");
+        return properties;
+    }
+
+    /**
+     * Get the String representation of some resource to be used as payload.
+     *
+     * @param resource
+     *            String representation of a given resource
+     * @return payload in String form
+     */
+    public String payloadFromResource(String resource) {
+        try {
+            return new String(toStringAndClose(getClass().getResourceAsStream(resource)).getBytes(Charsets.UTF_8));
+        } catch (IOException e) {
+            throw Throwables.propagate(e);
+        }
+    }
+}

--- a/src/test/java/com/cdancy/jenkins/rest/JenkinsAuthenticationMockTest.java
+++ b/src/test/java/com/cdancy/jenkins/rest/JenkinsAuthenticationMockTest.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cdancy.jenkins.rest;
+
+import javax.ws.rs.core.MediaType;
+
+import com.cdancy.jenkins.rest.JenkinsAuthentication;
+import com.cdancy.jenkins.rest.auth.AuthenticationType;
+import com.cdancy.jenkins.rest.exception.UndetectableCredentialTypeException;
+
+import org.jclouds.http.HttpRequest;
+
+import org.testng.annotations.Test;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import com.google.common.collect.Multimap;
+import static com.google.common.io.BaseEncoding.base64;
+
+import com.squareup.okhttp.mockwebserver.MockResponse;
+import com.squareup.okhttp.mockwebserver.MockWebServer;
+
+public class JenkinsAuthenticationMockTest {
+
+    @Test
+    public void testAnonymousAuthentication() throws Exception {
+        JenkinsAuthentication ja = JenkinsAuthentication.builder().build();
+        assertEquals(ja.identity, "anonymous");
+        assertEquals(ja.authType(), AuthenticationType.Anonymous);
+        assertEquals(ja.authValue(), base64().encode("anonymous:".getBytes()));
+        assertEquals(ja.credential, ja.authValue());
+    }
+
+    @Test
+    public void testUsernamePasswordAuthentication() throws Exception {
+        JenkinsAuthentication ja = JenkinsAuthentication.builder()
+            .credentials("user:password")
+            .build();
+        assertEquals(ja.identity, "user");
+        assertEquals(ja.authType(), AuthenticationType.UsernamePassword);
+        assertEquals(ja.authValue(), base64().encode("user:password".getBytes()));
+        assertEquals(ja.credential, ja.authValue());
+    }
+
+    @Test
+    public void testUsernameApiTokenAuthentication() throws Exception {
+        JenkinsAuthentication ja = JenkinsAuthentication.builder()
+            .apiToken("user:token")
+            .build();
+        assertEquals(ja.identity, "user");
+        assertEquals(ja.authType(), AuthenticationType.UsernameApiToken);
+        assertEquals(ja.authValue(), base64().encode("user:token".getBytes()));
+        assertEquals(ja.credential, ja.authValue());
+    }
+
+    @Test
+    public void testEncodedUsernamePasswordAuthentication() throws Exception {
+        String encoded = base64().encode("user:password".getBytes());
+        JenkinsAuthentication ja = JenkinsAuthentication.builder()
+            .credentials(encoded)
+            .build();
+        assertEquals(ja.identity, "user");
+        assertEquals(ja.authType(), AuthenticationType.UsernamePassword);
+        assertEquals(ja.authValue(), encoded);
+        assertEquals(ja.credential, ja.authValue());
+    }
+
+    @Test
+    public void testEncodedUsernameApiTokenAuthentication() throws Exception {
+        String encoded = base64().encode("user:token".getBytes());
+        JenkinsAuthentication ja = JenkinsAuthentication.builder()
+            .apiToken(encoded)
+            .build();
+        assertEquals(ja.identity, "user");
+        assertEquals(ja.authType(), AuthenticationType.UsernameApiToken);
+        assertEquals(ja.authValue(), encoded);
+        assertEquals(ja.credential, ja.authValue());
+    }
+
+    @Test
+    public void testEmptyUsernamePassword() {
+        JenkinsAuthentication ja = JenkinsAuthentication.builder()
+            .credentials(":")
+            .build();
+        assertEquals(ja.identity, "");
+        assertEquals(ja.authType(), AuthenticationType.UsernamePassword);
+        assertEquals(ja.authValue(), base64().encode(":".getBytes()));
+        assertEquals(ja.credential, ja.authValue());
+    }
+
+    @Test
+    public void testEmptyUsernameApiToken() {
+        JenkinsAuthentication ja = JenkinsAuthentication.builder()
+            .apiToken(":")
+            .build();
+        assertEquals(ja.identity, "");
+        assertEquals(ja.authType(), AuthenticationType.UsernameApiToken);
+        assertEquals(ja.authValue(), base64().encode(":".getBytes()));
+        assertEquals(ja.credential, ja.authValue());
+    }
+}

--- a/src/test/java/com/cdancy/jenkins/rest/TestUtilities.java
+++ b/src/test/java/com/cdancy/jenkins/rest/TestUtilities.java
@@ -43,8 +43,8 @@ public class TestUtilities extends JenkinsUtils {
     public static final String TEST_CREDENTIALS_SYSTEM_PROPERTY = "test.jenkins.rest.credentials";
     public static final String TEST_CREDENTIALS_ENVIRONMENT_VARIABLE = TEST_CREDENTIALS_SYSTEM_PROPERTY.replaceAll("\\.", "_").toUpperCase();
 
-    public static final String TEST_TOKEN_SYSTEM_PROPERTY = "test.jenkins.rest.token";
-    public static final String TEST_TOKEN_ENVIRONMENT_VARIABLE = TEST_TOKEN_SYSTEM_PROPERTY.replaceAll("\\.", "_").toUpperCase();
+    public static final String TEST_API_TOKEN_SYSTEM_PROPERTY = "test.jenkins.rest.api.token";
+    public static final String TEST_API_TOKEN_ENVIRONMENT_VARIABLE = TEST_API_TOKEN_SYSTEM_PROPERTY.replaceAll("\\.", "_").toUpperCase();
 
     private static final char[] CHARS = "abcdefghijklmnopqrstuvwxyz".toCharArray();
 
@@ -73,28 +73,30 @@ public class TestUtilities extends JenkinsUtils {
     }
 
     /**
-     * Find credentials (Basic, Bearer, or Anonymous) from system/environment.
+     * Find credentials (ApiToken, UsernamePassword, or Anonymous) from system/environment.
      *
      * @return JenkinsCredentials
      */
     public static JenkinsAuthentication inferTestAuthentication() {
 
-        // 1.) Check for "Basic" auth credentials.
         final JenkinsAuthentication.Builder inferAuth = JenkinsAuthentication.builder();
+
+        // 1.) Check for API Token as this requires no crumb hence is faster
         String authValue = JenkinsUtils
+                .retriveExternalValue(TEST_API_TOKEN_SYSTEM_PROPERTY,
+                        TEST_API_TOKEN_ENVIRONMENT_VARIABLE);
+        if (authValue != null) {
+            inferAuth.apiToken(authValue);
+            return inferAuth.build();
+        }
+
+        // 2.) Check for UsernamePassword auth credentials.
+        authValue = JenkinsUtils
                 .retriveExternalValue(TEST_CREDENTIALS_SYSTEM_PROPERTY,
                         TEST_CREDENTIALS_ENVIRONMENT_VARIABLE);
         if (authValue != null) {
             inferAuth.credentials(authValue);
-        } else {
-
-            // 2.) Check for "Bearer" auth token.
-            authValue = JenkinsUtils
-                    .retriveExternalValue(TEST_TOKEN_SYSTEM_PROPERTY,
-                            TEST_TOKEN_ENVIRONMENT_VARIABLE);
-            if (authValue != null) {
-                inferAuth.token(authValue);
-            }
+            return inferAuth.build();
         }
 
         // 3.) If neither #1 or #2 find anything "Anonymous" access is assumed.

--- a/src/test/java/com/cdancy/jenkins/rest/TestUtilities.java
+++ b/src/test/java/com/cdancy/jenkins/rest/TestUtilities.java
@@ -40,10 +40,10 @@ import org.jclouds.util.Strings2;
  */
 public class TestUtilities extends JenkinsUtils {
 
-    public static final String TEST_CREDENTIALS_SYSTEM_PROPERTY = "test.jenkins.rest.credentials";
+    public static final String TEST_CREDENTIALS_SYSTEM_PROPERTY = "test.jenkins.usernamePassword";
     public static final String TEST_CREDENTIALS_ENVIRONMENT_VARIABLE = TEST_CREDENTIALS_SYSTEM_PROPERTY.replaceAll("\\.", "_").toUpperCase();
 
-    public static final String TEST_API_TOKEN_SYSTEM_PROPERTY = "test.jenkins.rest.api.token";
+    public static final String TEST_API_TOKEN_SYSTEM_PROPERTY = "test.jenkins.usernameApiToken";
     public static final String TEST_API_TOKEN_ENVIRONMENT_VARIABLE = TEST_API_TOKEN_SYSTEM_PROPERTY.replaceAll("\\.", "_").toUpperCase();
 
     private static final char[] CHARS = "abcdefghijklmnopqrstuvwxyz".toCharArray();

--- a/src/test/java/com/cdancy/jenkins/rest/features/UserApiLiveTest.java
+++ b/src/test/java/com/cdancy/jenkins/rest/features/UserApiLiveTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.cdancy.jenkins.rest.features;
+
+import com.cdancy.jenkins.rest.BaseJenkinsApiLiveTest;
+import com.cdancy.jenkins.rest.domain.common.RequestStatus;
+import com.cdancy.jenkins.rest.domain.user.*;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+@Test(groups = "live", testName = "UserApiLiveTest", singleThreaded = true)
+public class UserApiLiveTest extends BaseJenkinsApiLiveTest {
+
+    ApiToken token;
+
+    @Test
+    public void testGetUser() {
+        User user = api().get();
+        assertNotNull(user);
+        assertNotNull(user.absoluteUrl());
+        assertEquals(user.absoluteUrl(), System.getProperty("test.jenkins.endpoint") + "/user/admin");
+        assertTrue(user.description() == null || user.description().equals(""));
+        assertNotNull(user.fullName());
+        assertEquals(user.fullName(), "admin");
+        assertNotNull(user.id());
+        assertEquals(user.id(), "admin");
+    }
+
+    @Test
+    public void testGenerateNewToken() {
+        token = api().generateNewToken("user-api-test-token");
+        assertNotNull(token);
+        assertEquals(token.status(), "ok");
+        assertNotNull(token.data());
+        assertNotNull(token.data().tokenName());
+        assertEquals(token.data().tokenName(), "user-api-test-token");
+        assertNotNull(token.data().tokenUuid());
+        assertNotNull(token.data().tokenValue());
+    }
+
+    @Test(dependsOnMethods = "testGenerateNewToken")
+    public void testRevokeApiToken() {
+        RequestStatus status = api().revoke(token.data().tokenUuid());
+        // Jenkins returns 200 whether the tokenUuid is correct or not.
+        assertTrue(status.value());
+    }
+
+    @Test
+    public void testRevokeApiTokenWithEmptyUuid() {
+        RequestStatus status = api().revoke("");
+        assertFalse(status.value());
+        // TODO: Deal with the HTML response from Jenkins Stapler
+    }
+
+    private UserApi api() {
+        return api.userApi();
+    }
+}

--- a/src/test/java/com/cdancy/jenkins/rest/features/UserApiMockTest.java
+++ b/src/test/java/com/cdancy/jenkins/rest/features/UserApiMockTest.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.cdancy.jenkins.rest.features;
+
+import com.cdancy.jenkins.rest.BaseJenkinsMockTest;
+import com.cdancy.jenkins.rest.JenkinsApi;
+import com.cdancy.jenkins.rest.domain.user.ApiToken;
+import com.cdancy.jenkins.rest.domain.user.User;
+import com.squareup.okhttp.mockwebserver.MockResponse;
+import com.squareup.okhttp.mockwebserver.MockWebServer;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+/**
+ * Mock tests for the {@link com.cdancy.jenkins.rest.features.JobsApi} class.
+ */
+@Test(groups = "unit", testName = "UserApiMockTest")
+public class UserApiMockTest extends BaseJenkinsMockTest {
+
+    @Test
+    public void testGetUser() throws Exception {
+        MockWebServer server = mockWebServer();
+
+        String body = payloadFromResource("/user.json");
+        server.enqueue(new MockResponse().setBody(body).setResponseCode(200));
+        JenkinsApi jenkinsApi = api(server.url("/").url());
+        UserApi api = jenkinsApi.userApi();
+        try {
+            User output = api.get();
+            assertNotNull(output);
+            assertNotNull(output.absoluteUrl());
+            assertEquals(output.absoluteUrl(), "http://localhost:8080/user/admin");
+            assertNull(output.description());
+            assertNotNull(output.fullName());
+            assertEquals(output.fullName(), "Administrator");
+            assertNotNull(output.id());
+            assertEquals(output.id(), "admin");
+            assertSent(server, "GET", "/user/user/api/json");
+        } finally {
+            jenkinsApi.close();
+            server.shutdown();
+        }
+    }
+
+    @Test
+    public void testGenerateNewApiToken() throws Exception {
+        MockWebServer server = mockWebServer();
+
+        String body = payloadFromResource("/api-token.json");
+        server.enqueue(new MockResponse().setBody(body).setResponseCode(200));
+        JenkinsApi jenkinsApi = api(server.url("/").url());
+        UserApi api = jenkinsApi.userApi();
+        try {
+            ApiToken output = api.generateNewToken("random");
+            assertNotNull(output);
+            assertNotNull(output.status());
+            assertEquals(output.status(), "ok");
+            assertNotNull(output.data());
+            assertNotNull(output.data().tokenName());
+            assertEquals(output.data().tokenName(), "kb-token");
+            assertNotNull(output.data().tokenUuid());
+            assertEquals(output.data().tokenUuid(), "8c42630b-4be5-4f51-b4e9-f17a8ac07521");
+            assertNotNull(output.data().tokenValue());
+            assertEquals(output.data().tokenValue(), "112fe6e9b1b94eb1ee58f0ea4f5a1ac7bf");
+            assertSentWithFormData(server, "POST", "/user/user/descriptorByName/jenkins.security.ApiTokenProperty/generateNewToken", "newTokenName=random");
+        } finally {
+            jenkinsApi.close();
+            server.shutdown();
+        }
+    }
+
+    // TODO: testRevokeApiToken
+    // TODO: testRevokeApiTokenWithEmptyUuid
+}

--- a/src/test/java/com/cdancy/jenkins/rest/filters/JenkinsAuthenticationFilterLiveTest.java
+++ b/src/test/java/com/cdancy/jenkins/rest/filters/JenkinsAuthenticationFilterLiveTest.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.cdancy.jenkins.rest.filters;
+
+import com.cdancy.jenkins.rest.BaseJenkinsTest;
+import com.cdancy.jenkins.rest.JenkinsApi;
+import com.cdancy.jenkins.rest.auth.AuthenticationType;
+import com.cdancy.jenkins.rest.domain.common.RequestStatus;
+import com.cdancy.jenkins.rest.domain.user.ApiToken;
+import com.cdancy.jenkins.rest.features.UserApi;
+
+import java.net.URL;
+
+import org.testng.annotations.Test;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.assertNotNull;
+
+@Test(groups = "live", testName = "FilterApiLiveTest", singleThreaded = true)
+public class JenkinsAuthenticationFilterLiveTest extends BaseJenkinsTest {
+    private final String endPoint = System.getProperty("test.jenkins.endpoint");
+
+    @Test
+    public void testAnonymousNeedsCrumb() throws Exception {
+        final String usernamePassword = System.getProperty("test.jenkins.usernamePassword");
+        JenkinsApi jenkinsApi = api(new URL(endPoint), AuthenticationType.Anonymous, null);
+
+        try {
+            // Do something that needs POST so the crumb logic is exercized
+            String config = payloadFromResource("/freestyle-project-no-params.xml");
+            RequestStatus success = jenkinsApi.jobsApi().create(null, "DevTest", config);
+            assertTrue(success.value());
+
+            // Delete the job
+            RequestStatus success2 = jenkinsApi.jobsApi().delete(null, "DevTest");
+            assertNotNull(success2);
+            assertTrue(success2.value());
+            // Debugging note: Jenkins returns 302 after POSTing the delete, causing JClouds to follow the redirect and POST again
+        } finally {
+            jenkinsApi.close();
+        }
+    }
+
+    @Test
+    public void testUsernamePasswordNeedsCrumb() throws Exception {
+        final String usernamePassword = System.getProperty("test.jenkins.usernamePassword");
+        JenkinsApi jenkinsApi = api(new URL(endPoint), AuthenticationType.UsernamePassword, usernamePassword);
+
+        try {
+            // Do something that needs POST so the crumb logic is exercized
+            String config = payloadFromResource("/freestyle-project-no-params.xml");
+            RequestStatus success = jenkinsApi.jobsApi().create(null, "DevTest", config);
+            assertTrue(success.value());
+
+            // Delete the job
+            RequestStatus success2 = jenkinsApi.jobsApi().delete(null, "DevTest");
+            assertNotNull(success2);
+            assertTrue(success2.value());
+            // Debugging note: Jenkins returns 302 after POSTing the delete, causing JClouds to follow the redirect and POST again
+        } finally {
+            jenkinsApi.close();
+        }
+    }
+
+    @Test
+    public void testUsernameApiTokenNeedsNoCrumb() throws Exception {
+        // Generate an API Token
+        final String usernamePassword = System.getProperty("test.jenkins.usernamePassword");
+        final ApiToken apiToken = generateNewApiToken(AuthenticationType.UsernamePassword, usernamePassword, "filter-test-token");
+
+        // Create a Jenkins Client using the API Token
+        System.out.println("Okay, we have the token: " + apiToken.data().tokenValue());
+        final String usernameApiToken = usernamePassword.split(":")[0] + ":" + apiToken.data().tokenValue();
+        JenkinsApi jenkinsApi = api(new URL(endPoint), AuthenticationType.UsernameApiToken, usernameApiToken);
+
+        try {
+            // Do something that needs POST so the crumb logic is exercized
+            String config = payloadFromResource("/freestyle-project-no-params.xml");
+            RequestStatus success = jenkinsApi.jobsApi().create(null, "DevTest", config);
+            assertTrue(success.value());
+
+            // Delete the job
+            RequestStatus success2 = jenkinsApi.jobsApi().delete(null, "DevTest");
+            assertNotNull(success2);
+            assertTrue(success2.value());
+            // Debugging note: Jenkins returns 302 after POSTing the delete, causing JClouds to follow the redirect and POST again
+        } finally {
+            jenkinsApi.close();
+            revokeApiToken(AuthenticationType.UsernameApiToken, usernameApiToken, apiToken);
+        }
+    }
+
+    private ApiToken generateNewApiToken(final AuthenticationType authType, final String credStr, final String tokenName) throws Exception {
+        JenkinsApi api = api(new URL(endPoint), authType, credStr);
+        UserApi user = api.userApi();
+        return user.generateNewToken(tokenName);
+    }
+
+    private void revokeApiToken(final AuthenticationType authType, final String credStr, final ApiToken apiToken) throws Exception {
+        JenkinsApi api = api(new URL(endPoint), authType, credStr);
+        UserApi user = api.userApi();
+        user.revoke(apiToken.data().tokenUuid());
+    }
+
+}

--- a/src/test/java/com/cdancy/jenkins/rest/filters/JenkinsAuthenticationFilterMockTest.java
+++ b/src/test/java/com/cdancy/jenkins/rest/filters/JenkinsAuthenticationFilterMockTest.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cdancy.jenkins.rest.filters;
+
+import javax.ws.rs.core.MediaType;
+
+import com.cdancy.jenkins.rest.JenkinsApi;
+import com.cdancy.jenkins.rest.JenkinsAuthentication;
+import com.cdancy.jenkins.rest.auth.AuthenticationType;
+import com.cdancy.jenkins.rest.BaseJenkinsMockTest;
+
+import org.jclouds.http.HttpRequest;
+
+import org.testng.annotations.Test;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import com.google.common.collect.Multimap;
+
+import com.squareup.okhttp.mockwebserver.MockResponse;
+import com.squareup.okhttp.mockwebserver.MockWebServer;
+
+public class JenkinsAuthenticationFilterMockTest extends BaseJenkinsMockTest {
+
+    @Test
+    public void testAnonymousNeedsCrumb() throws Exception {
+        MockWebServer server = mockWebServer();
+
+        final String value = "04a1109fc2db171362c966ebe9fc87f0";
+        server.enqueue(new MockResponse().setBody("Jenkins-Crumb:" + value).setResponseCode(200));
+        JenkinsApi jenkinsApi = api(server.getUrl("/"), AuthenticationType.Anonymous);
+
+        JenkinsAuthentication creds = creds(AuthenticationType.Anonymous);
+        JenkinsAuthenticationFilter filter = new JenkinsAuthenticationFilter(creds, jenkinsApi);
+        HttpRequest httpRequest = HttpRequest.builder().endpoint(server.getUrl("/").toString()).method("GET").build();
+        try {
+            httpRequest = filter.filter(httpRequest);
+            assertSentAcceptAuth(server, "GET", "/crumbIssuer/api/xml?xpath=concat%28//crumbRequestField,%22%3A%22,//crumb%29", MediaType.TEXT_PLAIN, AuthenticationType.Anonymous);
+            assertEquals(httpRequest.getEndpoint().toString(), server.getUrl("/").toString());
+            Multimap<String,String> headers = httpRequest.getHeaders();
+            assertEquals(headers.size(), 2);
+            assertTrue(headers.containsEntry("Jenkins-Crumb",value));
+            assertTrue(headers.containsEntry("Cookie",""));
+        } finally {
+            jenkinsApi.close();
+            server.shutdown();
+        }
+    }
+
+    @Test
+    public void testUsernamePasswordNeedsCrumb() throws Exception {
+        MockWebServer server = mockWebServer();
+
+        final String value = "04a1109fc2db171362c966ebe9fc87f0";
+        server.enqueue(new MockResponse().setBody("Jenkins-Crumb:" + value).setResponseCode(200));
+        JenkinsApi jenkinsApi = api(server.getUrl("/"), AuthenticationType.UsernamePassword);
+
+        JenkinsAuthentication creds = creds(AuthenticationType.UsernamePassword);
+        JenkinsAuthenticationFilter filter = new JenkinsAuthenticationFilter(creds, jenkinsApi);
+        HttpRequest httpRequest = HttpRequest.builder().endpoint(server.getUrl("/").toString()).method("GET").build();
+        try {
+            httpRequest = filter.filter(httpRequest);
+            assertSentAcceptAuth(server, "GET", "/crumbIssuer/api/xml?xpath=concat%28//crumbRequestField,%22%3A%22,//crumb%29", MediaType.TEXT_PLAIN, AuthenticationType.UsernamePassword);
+            assertEquals(httpRequest.getEndpoint().toString(), server.getUrl("/").toString());
+            Multimap<String,String> headers = httpRequest.getHeaders();
+            assertEquals(headers.size(), 3);
+            assertTrue(headers.containsEntry("Jenkins-Crumb",value));
+            assertTrue(headers.containsEntry("Authorization", creds.authType().getAuthScheme() + " " + creds.authValue()));
+            assertTrue(headers.containsEntry("Cookie",""));
+            System.out.println(httpRequest.toString());
+        } finally {
+            jenkinsApi.close();
+            server.shutdown();
+        }
+    }
+
+    @Test
+    public void testFilterApiTokenAuthType() throws Exception {
+        MockWebServer server = mockWebServer();
+
+        JenkinsApi jenkinsApi = api(server.getUrl("/"), AuthenticationType.ApiToken);
+
+        JenkinsAuthentication creds = creds(AuthenticationType.ApiToken);
+        JenkinsAuthenticationFilter filter = new JenkinsAuthenticationFilter(creds, jenkinsApi);
+        HttpRequest httpRequest = HttpRequest.builder().endpoint(server.getUrl("/").toString()).method("GET").build();
+        try {
+            httpRequest = filter.filter(httpRequest);
+            assertEquals(httpRequest.getEndpoint().toString(), server.getUrl("/").toString());
+            System.out.println(httpRequest.toString());
+            Multimap<String,String> headers = httpRequest.getHeaders();
+            assertEquals(headers.size(), 1);
+            assertTrue(headers.containsEntry("Authorization", creds.authType().getAuthScheme() + " " + creds.authValue()));
+        } finally {
+            jenkinsApi.close();
+            server.shutdown();
+        }
+    }
+}

--- a/src/test/resources/api-token.json
+++ b/src/test/resources/api-token.json
@@ -1,0 +1,8 @@
+{
+  "status":"ok",
+  "data":{
+    "tokenName":"kb-token",
+    "tokenUuid":"8c42630b-4be5-4f51-b4e9-f17a8ac07521",
+    "tokenValue":"112fe6e9b1b94eb1ee58f0ea4f5a1ac7bf"
+  }
+}

--- a/src/test/resources/user.json
+++ b/src/test/resources/user.json
@@ -1,0 +1,37 @@
+{
+  "_class" : "hudson.model.User",
+  "absoluteUrl" : "http://localhost:8080/user/admin",
+  "description" : null,
+  "fullName" : "Administrator",
+  "id" : "admin",
+  "property" : [
+    {
+      "_class" : "jenkins.security.ApiTokenProperty"
+    },
+    {
+      "_class" : "com.cloudbees.plugins.credentials.UserCredentialsProvider$UserCredentialsProperty"
+    },
+    {
+      "_class" : "hudson.model.MyViewsProperty"
+    },
+    {
+      "_class" : "hudson.model.PaneStatusProperties"
+    },
+    {
+      "_class" : "jenkins.security.seed.UserSeedProperty"
+    },
+    {
+      "_class" : "hudson.search.UserSearchProperty",
+      "insensitiveSearch" : true
+    },
+    {
+      "_class" : "hudson.model.TimeZoneProperty"
+    },
+    {
+      "_class" : "hudson.security.HudsonPrivateSecurityRealm$Details"
+    },
+    {
+      "_class" : "jenkins.security.LastGrantedAuthoritiesProperty"
+    }
+  ]
+}


### PR DESCRIPTION
# Background

This fixes the crumb issue #169 

The Jenkins [documentation](https://www.jenkins.io/doc/book/security/csrf-protection/#working-with-scripted-clients) states that:

* Clients that authenticate using a `username:password` must request a crumb.
* Requests authenticating with an API token are exempt from CSRF protection in Jenkins (no crumb needed).

Furthermore, the [Cloudbees documentation](https://support.cloudbees.com/hc/en-us/articles/219257077-CSRF-Protection-Explained#resolution) states that:

* Anonymous access must request a crumb.

Anonymous access is rare but possible. It happens when users start Jenkins without the wizard and without configuring users.

# Solution description

The main difficulty faced when addressing this issue is that the current jenkins-rest implementation does not clearly distinguishes between `username:password` and `username:apiToken`. The only way I could solve it was by introducing a the new `JenkinsClient.builder().apiToken("username:apiToken")` API.

Note that jenkins-rest has a [Bearer Token](https://datatracker.ietf.org/doc/html/rfc6750) implementation, but Jenkins supports no such thing. This PR removes the Bearer Token implementation in favor of what Jenkins supports: Anonymous Authentication and Basic Authentication. Basic Authentication is used for both `username:password` and `username:apiToken`.

# Testing

There are three cases to test:

1. Anonymous access
2. Username and password
3. Username and API Token

I have tested all cases on a local live server, however providing unit and integration tests requires more work.

I am not sure how to provide tests for 1. and 3. The docker container used for Live tests is preconfigured using [`username:password`](https://github.com/cdancy/jenkins-rest/blob/9d0739494e52643bf3e7872280ea97aff7bda0e6/src/main/docker/init.groovy.d/Security.groovy) which means we're currently only testing for case 2.

It is possible to obtain an [API Token using the REST API](https://support.cloudbees.com/hc/en-us/articles/115003090592-How-to-re-generate-my-Jenkins-user-token), so conceivably a test can be written for case 3. I just haven't gotten to that part yet.