### PR TITLE
Upgrade to Jenkins' recommended plugin installation method

### DIFF
--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -5,9 +5,9 @@ FROM jenkins/jenkins:$jenkins_tag
 COPY init.groovy.d/ /usr/share/jenkins/ref/init.groovy.d/
 
 # Plugins
-COPY plugins.txt /usr/share/jenkins/ref/plugins.txt
+COPY --chown=jenkins:jenkins plugins.yml /usr/share/jenkins/ref/plugins.yml
 # the grep command allows to ignore all comments in the plugins.txt file
-RUN xargs /usr/local/bin/install-plugins.sh `grep -v '^#' /usr/share/jenkins/ref/plugins.txt`
+RUN jenkins-plugin-cli -f /usr/share/jenkins/ref/plugins.yml
 
 # Skip initial setup
 ENV JAVA_OPTS -Djenkins.install.runSetupWizard=false

--- a/src/main/docker/plugins.txt
+++ b/src/main/docker/plugins.txt
@@ -1,5 +1,0 @@
-antisamy-markup-formatter:2.5
-cloudbees-credentials:3.3
-cloudbees-folder:6.16
-configuration-as-code:1.55
-workflow-aggregator:2.6

--- a/src/main/docker/plugins.yml
+++ b/src/main/docker/plugins.yml
@@ -1,0 +1,16 @@
+plugins:
+    - artifactId: antisamy-markup-formatter
+      source:
+          version: 2.5
+    - artifactId: cloudbees-credentials
+      source:
+          version: 3.3
+    - artifactId: cloudbees-folder
+      source:
+          version: 6.17
+    - artifactId: configuration-as-code
+      source:
+          version: 1.55.1
+    - artifactId: workflow-aggregator
+      source:
+          version: 2.6


### PR DESCRIPTION
The Jenkins image makes this recommendation when building the container:

```
$ docker build -t jenkins-rest/jenkins src/main/docker
...
Step 5/6 : RUN xargs /usr/local/bin/install-plugins.sh `grep -v '^#' /usr/share/jenkins/ref/plugins.txt`
 ---> Running in f5dcb862bb6f
WARN: install-plugins.sh is deprecated, please switch to jenkins-plugin-cli
```

This PR implements this recommendation. Mock and integration tests pass locally.