### PR TITLE
Fix permission on init.groovy.d in the docker container

### DIFF
--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -2,7 +2,7 @@ ARG jenkins_tag=2.277.4-jdk11
 
 FROM jenkins/jenkins:$jenkins_tag
 
-COPY init.groovy.d/ /usr/share/jenkins/ref/init.groovy.d/
+COPY --chown=jenkins:jenkins init.groovy.d/ /usr/share/jenkins/ref/init.groovy.d/
 
 # Plugins
 COPY --chown=jenkins:jenkins plugins.yml /usr/share/jenkins/ref/plugins.yml


### PR DESCRIPTION
When cloning this git repository using a restrictive umask (e.g. 0027), the permission on the init.groovy.d makes it unreadable by the jenkins account inside the container (e.g. readable by the local host user but not by the group or by others inside the container).

This manifests itself by Jenkins silently not running the Security.groovy setup script, followed by a failure in the integration tests where the anonymous user shows up where the admin user is expected.

This PR fixes this problem.