### PR TITLE
Poll rather than wait in the JobsApiLiveTest

### DIFF
--- a/src/test/java/com/cdancy/jenkins/rest/features/JobsApiLiveTest.java
+++ b/src/test/java/com/cdancy/jenkins/rest/features/JobsApiLiveTest.java
@@ -204,20 +204,18 @@ public class JobsApiLiveTest extends BaseJenkinsApiLiveTest {
     }
 
     @Test(dependsOnMethods = "testLastBuildTimestampOnJobWithNoBuilds")
-    public void testBuildJob() {
+    public void testBuildJob() throws InterruptedException {
         queueId = api().build(null, "DevTest");
         assertNotNull(queueId);
         assertTrue(queueId.value() > 0);
         assertTrue(queueId.errors().size() == 0);
+        // Before we exit the test, wait until the job runs
+        QueueItem queueItem = getRunningQueueItem(queueId.value());
+        BuildInfo buildInfo = getCompletedBuild("DevTest", queueItem);
     }
 
     @Test(dependsOnMethods = "testBuildJob")
     public void testLastBuildNumberOnJob() {
-        try {
-            Thread.sleep(10000);
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-        }
         buildNumber = api().lastBuildNumber(null, "DevTest");
         assertNotNull(buildNumber);
         assertTrue(buildNumber == 1);


### PR DESCRIPTION
The diff pretty much sums it up. Rather than waiting some wall clock time, wait for the build to start and complete. Shaves a few seconds off the live test, and is a better approach.