### PR TITLE
Fix javadoc missing and undefined module issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
-jdk: openjdk11
+jdk: openjdk17
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/build.gradle
+++ b/build.gradle
@@ -101,3 +101,12 @@ task integTest(type: Test, dependsOn: mockTest) {
         "test.jenkins.usernamePassword" : testJenkinsUsernamePassword
     ] << usernameApiToken
 }
+
+javadoc {
+    source = sourceSets.main.allJava
+    options.with {
+        links "https://docs.oracle.com/en/java/javase/${compatibilityVersion}/docs/api"
+        links "https://google.github.io/guice/api-docs/${dependencies.guiceVersion}/javadoc/"
+        addStringOption('Xdoclint:none', '-quiet')
+    }
+}


### PR DESCRIPTION
The javadoc currently don't work well. For example, when they are picked up by javadoc.io, they looks like so:
https://javadoc.io/doc/io.github.cdancy/jenkins-rest/latest/undefined/com/cdancy/jenkins/rest/JenkinsClient.html

There are a few issues:

* The search box is not working, this is caused by this project not using modules.
* The link to base classes is broken (caused by missing javadoc configuration links)
* Java 11 has a javadoc bug with missing modules (https://bugs.openjdk.java.net/browse/JDK-8215291)

All that is solved when:

* upgrading the build system to Java 17
* adding a javadoc closure to build.gradle
