### PR TITLE
Remove versions to fix dependency conflict

### DIFF
--- a/src/main/docker/plugins.yml
+++ b/src/main/docker/plugins.yml
@@ -1,16 +1,6 @@
 plugins:
     - artifactId: antisamy-markup-formatter
-      source:
-          version: 2.5
     - artifactId: cloudbees-credentials
-      source:
-          version: 3.3
     - artifactId: cloudbees-folder
-      source:
-          version: 6.17
     - artifactId: configuration-as-code
-      source:
-          version: 1.55.1
     - artifactId: workflow-aggregator
-      source:
-          version: 2.6


### PR DESCRIPTION
This solves #222 .

The best alternative to this solution is to list the versions of all plugins (including transitive ones), not just the core ones. This solution works as long as the Jenkins plugin dependency resolution brings in plugin versions that are compatible with one another, and that do not break backward compatibility.