### PR TITLE
ISSUE-237: fallback to set-cookie when Set-Cookie header is not avail…

### DIFF
--- a/src/main/java/com/cdancy/jenkins/rest/parsers/CrumbParser.java
+++ b/src/main/java/com/cdancy/jenkins/rest/parsers/CrumbParser.java
@@ -23,6 +23,7 @@ import com.cdancy.jenkins.rest.domain.crumb.Crumb;
 
 import com.google.common.base.Function;
 import java.io.IOException;
+import java.util.Collection;
 
 import javax.inject.Singleton;
 import javax.ws.rs.core.HttpHeaders;
@@ -60,9 +61,18 @@ public class CrumbParser implements Function<HttpResponse, Crumb> {
     }
 
     private static String sessionIdCookie(HttpResponse input) {
-        return input.getHeaders().get(HttpHeaders.SET_COOKIE).stream()
+        return setCookieValues(input).stream()
             .filter(c -> c.startsWith(JENKINS_COOKIES_JSESSIONID))
             .findFirst()
             .orElse("");
+    }
+
+    private static Collection<String> setCookieValues(HttpResponse input) {
+        Collection<String> setCookieValues = input.getHeaders().get(HttpHeaders.SET_COOKIE);
+        if(setCookieValues.isEmpty()) {
+            return input.getHeaders().get(HttpHeaders.SET_COOKIE.toLowerCase());
+        } else {
+            return setCookieValues;
+        }
     }
 }


### PR DESCRIPTION
Trying to call the API com.cdancy.jenkins.rest.features.JobsApi#build we got failure with the following reason:

HTTP CODE: 403 
Error description: No valid crumb was included in the request

We enabled the http debug log and we noticed that the JSESSION ID was not sent back by the library when the build api was called.

This because our Jenkins instance sent back a "set-cookie" header when the crumb API is called, but the crumb parser expect a "Set-Cookie" header.

Falling back to "set-cookie" header when "Set-Cookie" is not available fixed the problem.