### PR TITLE
Compatibility fix for Java 11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ dependencies {
     testImplementation ('ch.qos.logback:logback-classic:1.4.1')
 }
 
-ext.compatibilityVersion = JavaVersion.VERSION_1_8
+ext.compatibilityVersion = JavaVersion.VERSION_11
 ext.javadocPath = compatibilityVersion.isJava8() ? '' : 'en/java/'
 sourceCompatibility = compatibilityVersion
 targetCompatibility = compatibilityVersion


### PR DESCRIPTION
Currently the master branch does not build. It fails with lots of errors like this one:

```
- Variant 'antApiElements' capability org.testng:testng-ant:7.6.1 declares an API of a library, packaged as a jar, and its dependencies declared externally:
    - Incompatible because this component declares a component compatible with Java 11 and the consumer needed a component compatible with Java 8
```

This PR aims to fix this problem so the library can be built and we can restore sanity to the master branch.