### PR TITLE
Extensive build info

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ dependencies {
     testImplementation ('ch.qos.logback:logback-classic:1.4.1')
 }
 
-ext.compatibilityVersion = JavaVersion.VERSION_1_8
+ext.compatibilityVersion = JavaVersion.VERSION_11
 ext.javadocPath = compatibilityVersion.isJava8() ? '' : 'en/java/'
 sourceCompatibility = compatibilityVersion
 targetCompatibility = compatibilityVersion

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG jenkins_tag=2.277.4-jdk11
+ARG jenkins_tag=2.303.3-lts-jdk11
 
 FROM jenkins/jenkins:$jenkins_tag
 

--- a/src/main/docker/plugins.yml
+++ b/src/main/docker/plugins.yml
@@ -4,3 +4,4 @@ plugins:
     - artifactId: cloudbees-folder
     - artifactId: configuration-as-code
     - artifactId: workflow-aggregator
+    - artifactId: badge

--- a/src/main/java/com/cdancy/jenkins/rest/domain/job/Action.java
+++ b/src/main/java/com/cdancy/jenkins/rest/domain/job/Action.java
@@ -19,6 +19,7 @@ package com.cdancy.jenkins.rest.domain.job;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
+import org.jclouds.javax.annotation.Nullable;
 import org.jclouds.json.SerializedNames;
 
 import java.util.List;
@@ -30,14 +31,24 @@ public abstract class Action {
 
     public abstract List<Parameter> parameters();
 
+    @Nullable
+    public abstract String text();
+
+    @Nullable
+    public abstract String iconPath();
+
+    @Nullable
+    public abstract String _class();
     Action() {
     }
 
-    @SerializedNames({"causes", "parameters"})
-    public static Action create(final List<Cause> causes, final List<Parameter> parameters) {
+    @SerializedNames({"causes", "parameters", "text", "iconPath", "_class"})
+    public static Action create(final List<Cause> causes, final List<Parameter> parameters, final String text, final String iconPath, final String _class) {
         return new AutoValue_Action(
             causes != null ? ImmutableList.copyOf(causes) : ImmutableList.<Cause>of(),
-            parameters != null ? ImmutableList.copyOf(parameters) : ImmutableList.<Parameter>of());
+            parameters != null ? ImmutableList.copyOf(parameters) : ImmutableList.<Parameter>of(),
+            text, iconPath, _class
+        );
     }
 }
 

--- a/src/test/java/com/cdancy/jenkins/rest/features/JobsApiMockTest.java
+++ b/src/test/java/com/cdancy/jenkins/rest/features/JobsApiMockTest.java
@@ -127,6 +127,12 @@ public class JobsApiMockTest extends BaseJenkinsMockTest {
             assertNotNull(output);
             assertEquals(output.fullDisplayName(), "fish #10");
             assertEquals(output.artifacts().size(), 1);
+            assertEquals(output.actions().size(), 5);
+            assertEquals(output.actions().get(2).text(), "<strong>There could be HTML text here</strong>");
+            assertEquals(output.actions().get(2).iconPath(), "clipboard.png");
+            assertEquals(output.actions().get(2)._class(), "com.jenkinsci.plugins.badge.action.BadgeSummaryAction");
+            assertEquals(output.actions().get(3).text(), null);
+            assertEquals(output.actions().get(4)._class(), "org.jenkinsci.plugins.displayurlapi.actions.RunDisplayAction");
             assertSent(server, "GET", "/job/fish/10/api/json");
         } finally {
             jenkinsApi.close();

--- a/src/test/resources/build-info.json
+++ b/src/test/resources/build-info.json
@@ -20,6 +20,15 @@
           "userName" : "anonymous"
         }
       ]
+    },
+    {
+       "text" : "<strong>There could be HTML text here</strong>",
+       "iconPath" : "clipboard.png",
+       "_class" : "com.jenkinsci.plugins.badge.action.BadgeSummaryAction"
+    },
+    {},
+    {
+       "_class" : "org.jenkinsci.plugins.displayurlapi.actions.RunDisplayAction"
     }
   ],
   "artifacts" : [

--- a/src/test/resources/pipeline-with-action.xml
+++ b/src/test/resources/pipeline-with-action.xml
@@ -1,0 +1,12 @@
+<flow-definition plugin="workflow-job@1145.v7f2433caa07f">
+    <actions/>
+    <description/>
+    <keepDependencies>false</keepDependencies>
+    <properties/>
+    <definition class="org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition" plugin="workflow-cps@2648.va9433432b33c">
+        <script>node { createSummary("error.svg").appendText("Hudson, we have a problem.", false, false, false, "red"); }</script>
+        <sandbox>true</sandbox>
+    </definition>
+    <triggers/>
+    <disabled>false</disabled>
+</flow-definition>


### PR DESCRIPTION
This PR adds the ability to read `_class` types of build actions. Jenkins can produce build actions in the build info that look like this:

```json
{
  "actions" : [
    {
       "text" : "Hudson, we have a problem.",
       "iconPath" : "error.svg",
       "_class" : "com.jenkinsci.plugins.badge.action.BadgeSummaryAction"
    },
    {
       "_class" : "org.jenkinsci.plugins.displayurlapi.actions.RunDisplayAction"
    }
    ]
}
```

These are created by pipeline code such as:
```groovy
createSummary("error.svg").appendText("Hudson, we have a problem.", false, false, false, "red")
```

With this PR, we can read these build actions in the `BuildInfo`.
