### PR TITLE
Adding support for the /safeExit method to enable safe shutdown using the API

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group = io.github.cdancy
-version = 1.0.2
+version = 1.1.0
 
 artifactoryURL = http://127.0.0.1:8080/artifactory
 artifactoryUser = admin

--- a/src/main/java/com/cdancy/jenkins/rest/domain/system/SystemInfo.java
+++ b/src/main/java/com/cdancy/jenkins/rest/domain/system/SystemInfo.java
@@ -56,4 +56,5 @@ public abstract class SystemInfo implements ErrorsHolder {
                 hudsonVersion, jenkinsVersion, jenkinsSession, 
                 instanceIdentity, sshEndpoint, server);
     }
+   
 }

--- a/src/main/java/com/cdancy/jenkins/rest/features/SystemApi.java
+++ b/src/main/java/com/cdancy/jenkins/rest/features/SystemApi.java
@@ -61,5 +61,13 @@ public interface SystemApi {
    @Consumes(MediaType.TEXT_HTML)
    @POST
    RequestStatus cancelQuietDown();
+   
+   @Named("system:safe-exit")
+   @Path("safeExit")
+   @Fallback(JenkinsFallbacks.RequestStatusOnError.class)
+   @ResponseParser(RequestStatusParser.class)
+   @Consumes(MediaType.TEXT_HTML)
+   @POST
+   RequestStatus safeExit();
 
 }

--- a/src/main/java/com/cdancy/jenkins/rest/parsers/SystemInfoFromJenkinsHeaders.java
+++ b/src/main/java/com/cdancy/jenkins/rest/parsers/SystemInfoFromJenkinsHeaders.java
@@ -30,6 +30,9 @@ import com.google.common.base.Function;
  */
 @Singleton
 public class SystemInfoFromJenkinsHeaders implements Function<HttpResponse, SystemInfo> {
+	
+	private static final String DEFAULT_EMPTY_HEADER_STRING = "information not available";
+	
 
     @Override
     public SystemInfo apply(HttpResponse response) {
@@ -41,10 +44,15 @@ public class SystemInfoFromJenkinsHeaders implements Function<HttpResponse, Syst
         if (statusCode >= 200 && statusCode < 400) {
             return SystemInfo.create(response.getFirstHeaderOrNull("X-Hudson"), response.getFirstHeaderOrNull("X-Jenkins"),
                 response.getFirstHeaderOrNull("X-Jenkins-Session"),
-                response.getFirstHeaderOrNull("X-Instance-Identity"), response.getFirstHeaderOrNull("X-SSH-Endpoint"),
-                response.getFirstHeaderOrNull("Server"), null);
+                response.getFirstHeaderOrNull("X-Instance-Identity"), getFirstHeaderOrDefault(response, "X-SSH-Endpoint"),
+                getFirstHeaderOrDefault(response, "Server"), null);
         } else {
             throw new RuntimeException(response.getStatusLine());
         }
+    }
+    
+    private String getFirstHeaderOrDefault(HttpResponse response, String header) {
+    	String headerFromResponse = response.getFirstHeaderOrNull(header);
+    	return (headerFromResponse != null) ? headerFromResponse : DEFAULT_EMPTY_HEADER_STRING;    	
     }
 }

--- a/src/test/java/com/cdancy/jenkins/rest/features/SystemApiMockTest.java
+++ b/src/test/java/com/cdancy/jenkins/rest/features/SystemApiMockTest.java
@@ -147,4 +147,21 @@ public class SystemApiMockTest extends BaseJenkinsMockTest {
             server.shutdown();
         }
     }
+    
+    public void testSafeExit() throws Exception {
+        MockWebServer server = mockWebServer();
+
+        server.enqueue(new MockResponse().setResponseCode(200));
+        JenkinsApi jenkinsApi = api(server.url("/").url());
+        SystemApi api = jenkinsApi.systemApi();
+        try {
+            RequestStatus success = api.safeExit();
+            assertNotNull(success);
+            assertTrue(success.value());
+            assertSentAccept(server, "POST", "/safeExit", MediaType.TEXT_HTML);
+        } finally {
+            jenkinsApi.close();
+            server.shutdown();
+        }
+    }
 }


### PR DESCRIPTION
**On adding new feautes/endpoints**

Adding support to automated shutdown of jenkins using the `/safeExit` functionality.

**On adding Mock and Integ Tests**

At _least_ 2 mock tests and 2 integ tests are required prior to merging. 
Each pair should should test what the success and failure of added change looks like.
More complicated additions will of course require more tests.

**On CI testing (currently using travis)**

Code will not be reviewed until CI passes.
Current CI does NOT exercise `integ` tests and so each Pull Request will have to be run manually by one of the maintainers to confirm it works as expected: please be patient.

**On automtatic closing of ISSUES**

Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
