### PR TITLE
Issue-315: Processing Queue ID as a long value

### DIFF
--- a/src/main/java/com/cdancy/jenkins/rest/domain/common/LongResponse.java
+++ b/src/main/java/com/cdancy/jenkins/rest/domain/common/LongResponse.java
@@ -26,21 +26,21 @@ import com.cdancy.jenkins.rest.JenkinsUtils;
 import com.google.auto.value.AutoValue;
 
 /**
- * Integer response to be returned when an endpoint returns
- * an integer.
- * 
- * <p>When the HTTP response code is valid the `value` parameter will 
- * be set to the integer value while a non-valid response has the `value` set to
+ * Long response to be returned when an endpoint returns
+ * an long.
+ *
+ * <p>When the HTTP response code is valid the `value` parameter will
+ * be set to the long value while a non-valid response has the `value` set to
  * null along with any potential `error` objects returned from Jenkins.
  */
 @AutoValue
-public abstract class IntegerResponse implements Value<Integer>, ErrorsHolder {
-    
+public abstract class LongResponse implements Value<Long>, ErrorsHolder {
+
     @SerializedNames({ "value", "errors" })
-    public static IntegerResponse create(@Nullable final Integer value, 
+    public static LongResponse create(@Nullable final Long value,
             final List<Error> errors) {
-        
-        return new AutoValue_IntegerResponse(value, 
+
+        return new AutoValue_LongResponse(value,
                 JenkinsUtils.nullToEmpty(errors));
     }
 }

--- a/src/main/java/com/cdancy/jenkins/rest/fallbacks/JenkinsFallbacks.java
+++ b/src/main/java/com/cdancy/jenkins/rest/fallbacks/JenkinsFallbacks.java
@@ -22,7 +22,7 @@ import static com.google.common.base.Throwables.propagate;
 
 import static org.jclouds.http.HttpUtils.returnValueOnCodeOrNull;
 
-import com.cdancy.jenkins.rest.domain.common.IntegerResponse;
+import com.cdancy.jenkins.rest.domain.common.LongResponse;
 import com.cdancy.jenkins.rest.domain.common.RequestStatus;
 import com.cdancy.jenkins.rest.domain.common.Error;
 import com.cdancy.jenkins.rest.domain.crumb.Crumb;
@@ -59,14 +59,14 @@ public final class JenkinsFallbacks {
         }
     }
 
-    public static final class IntegerResponseOnError implements Fallback<Object> {
+    public static final class LongResponseOnError implements Fallback<Object> {
         @Override
         public Object createOrPropagate(final Throwable throwable) {
             checkNotNull(throwable, "throwable");
             try {
-                return IntegerResponse.create(null, getErrors(throwable));
+                return LongResponse.create(null, getErrors(throwable));
             } catch (JsonSyntaxException e) {
-                return IntegerResponse.create(null, getErrors(e));
+                return LongResponse.create(null, getErrors(e));
             }
         }
     }

--- a/src/main/java/com/cdancy/jenkins/rest/features/JobsApi.java
+++ b/src/main/java/com/cdancy/jenkins/rest/features/JobsApi.java
@@ -46,7 +46,7 @@ import org.jclouds.rest.annotations.RequestFilters;
 import org.jclouds.rest.annotations.ResponseParser;
 
 import com.cdancy.jenkins.rest.binders.BindMapToForm;
-import com.cdancy.jenkins.rest.domain.common.IntegerResponse;
+import com.cdancy.jenkins.rest.domain.common.LongResponse;
 import com.cdancy.jenkins.rest.domain.common.RequestStatus;
 import com.cdancy.jenkins.rest.fallbacks.JenkinsFallbacks;
 import com.cdancy.jenkins.rest.filters.JenkinsAuthenticationFilter;
@@ -164,11 +164,11 @@ public interface JobsApi {
 
     @Named("jobs:build")
     @Path("{optionalFolderPath}job/{name}/build")
-    @Fallback(JenkinsFallbacks.IntegerResponseOnError.class)
+    @Fallback(JenkinsFallbacks.LongResponseOnError.class)
     @ResponseParser(LocationToQueueId.class)
     @Consumes("application/unknown")
     @POST
-    IntegerResponse build(@Nullable @PathParam("optionalFolderPath") @ParamParser(OptionalFolderPathParser.class) String optionalFolderPath,
+    LongResponse build(@Nullable @PathParam("optionalFolderPath") @ParamParser(OptionalFolderPathParser.class) String optionalFolderPath,
                   @PathParam("name") String jobName);
 
     @Named("jobs:stop-build")
@@ -203,11 +203,11 @@ public interface JobsApi {
 
     @Named("jobs:build-with-params")
     @Path("{optionalFolderPath}job/{name}/buildWithParameters")
-    @Fallback(JenkinsFallbacks.IntegerResponseOnError.class)
+    @Fallback(JenkinsFallbacks.LongResponseOnError.class)
     @ResponseParser(LocationToQueueId.class)
     @Consumes("application/unknown")
     @POST
-    IntegerResponse buildWithParameters(@Nullable @PathParam("optionalFolderPath") @ParamParser(OptionalFolderPathParser.class) String optionalFolderPath,
+    LongResponse buildWithParameters(@Nullable @PathParam("optionalFolderPath") @ParamParser(OptionalFolderPathParser.class) String optionalFolderPath,
                                 @PathParam("name") String jobName,
                                 @Nullable @BinderParam(BindMapToForm.class) Map<String, List<String>> properties);
 

--- a/src/main/java/com/cdancy/jenkins/rest/features/QueueApi.java
+++ b/src/main/java/com/cdancy/jenkins/rest/features/QueueApi.java
@@ -52,7 +52,7 @@ public interface QueueApi {
 
     /**
      * Get a specific queue item.
-     * 
+     *
      * Queue items are builds that have been scheduled to run, but are waiting for a slot.
      * You can poll the queueItem that corresponds to a build to detect whether the build is still pending or is executing.
      * @param queueId The queue id value as returned by the JobsApi build or buildWithParameters methods.
@@ -61,11 +61,11 @@ public interface QueueApi {
     @Named("queue:item")
     @Path("/item/{queueId}/api/json")
     @GET
-    QueueItem queueItem(@PathParam("queueId") int queueId);
+    QueueItem queueItem(@PathParam("queueId") long queueId);
 
     /**
      * Cancel a queue item before it gets built.
-     * 
+     *
      * @param id The queue id value of the queue item to cancel.
      *           This is the value is returned by the JobsApi build or buildWithParameters methods.
      * @return Always returns true due to JENKINS-21311.
@@ -75,5 +75,5 @@ public interface QueueApi {
     @Fallback(JenkinsFallbacks.JENKINS_21311.class)
     @ResponseParser(RequestStatusParser.class)
     @POST
-    RequestStatus cancel(@FormParam("id") int id);
+    RequestStatus cancel(@FormParam("id") long id);
 }

--- a/src/main/java/com/cdancy/jenkins/rest/parsers/LocationToQueueId.java
+++ b/src/main/java/com/cdancy/jenkins/rest/parsers/LocationToQueueId.java
@@ -28,17 +28,17 @@ import com.google.common.base.Function;
 import com.google.common.collect.Lists;
 
 import com.cdancy.jenkins.rest.domain.common.Error;
-import com.cdancy.jenkins.rest.domain.common.IntegerResponse;
+import com.cdancy.jenkins.rest.domain.common.LongResponse;
 
 /**
  * Created by dancc on 3/11/16.
  */
 @Singleton
-public class LocationToQueueId implements Function<HttpResponse, IntegerResponse> {
+public class LocationToQueueId implements Function<HttpResponse, LongResponse> {
 
    private static final Pattern pattern = Pattern.compile("^.*/queue/item/(\\d+)/$");
 
-   public IntegerResponse apply(HttpResponse response) {
+   public LongResponse apply(HttpResponse response) {
        if (response == null) {
            throw new RuntimeException("Unexpected NULL HttpResponse object");
        }
@@ -47,12 +47,12 @@ public class LocationToQueueId implements Function<HttpResponse, IntegerResponse
       if (url != null) {
          Matcher matcher = pattern.matcher(url);
          if (matcher.find() && matcher.groupCount() == 1) {
-            return IntegerResponse.create(Integer.valueOf(matcher.group(1)), null);
+            return LongResponse.create(Long.valueOf(matcher.group(1)), null);
          }
       }
       final Error error = Error.create(null,
          "No queue item Location header could be found despite getting a valid HTTP response.",
          NumberFormatException.class.getCanonicalName());
-      return IntegerResponse.create(null, Lists.newArrayList(error));
+      return LongResponse.create(null, Lists.newArrayList(error));
    }
 }

--- a/src/test/java/com/cdancy/jenkins/rest/BaseJenkinsApiLiveTest.java
+++ b/src/test/java/com/cdancy/jenkins/rest/BaseJenkinsApiLiveTest.java
@@ -80,7 +80,7 @@ public class BaseJenkinsApiLiveTest extends BaseApiLiveTest<JenkinsApi> {
      *         The caller has to check the value of queueItem.executable, and if it is null, the queue item is still pending.
      *
      */
-    protected QueueItem getRunningQueueItem(int queueId) throws InterruptedException {
+    protected QueueItem getRunningQueueItem(long queueId) throws InterruptedException {
         int max = 10;
         QueueItem queueItem = api.queueApi().queueItem(queueId);
         while (max > 0) {

--- a/src/test/java/com/cdancy/jenkins/rest/features/JobsApiLiveTest.java
+++ b/src/test/java/com/cdancy/jenkins/rest/features/JobsApiLiveTest.java
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.cdancy.jenkins.rest.BaseJenkinsApiLiveTest;
-import com.cdancy.jenkins.rest.domain.common.IntegerResponse;
+import com.cdancy.jenkins.rest.domain.common.LongResponse;
 import com.cdancy.jenkins.rest.domain.common.RequestStatus;
 import com.cdancy.jenkins.rest.domain.job.*;
 import com.cdancy.jenkins.rest.domain.plugins.Plugin;
@@ -35,8 +35,8 @@ import static org.testng.Assert.*;
 @Test(groups = "live", testName = "JobsApiLiveTest", singleThreaded = true)
 public class JobsApiLiveTest extends BaseJenkinsApiLiveTest {
 
-    private IntegerResponse queueId;
-    private IntegerResponse queueIdForAnotherJob;
+    private LongResponse queueId;
+    private LongResponse queueIdForAnotherJob;
     private Integer buildNumber;
     private static final String FOLDER_PLUGIN_NAME = "cloudbees-folder";
     private static final String FOLDER_PLUGIN_VERSION = "latest";
@@ -58,7 +58,7 @@ public class JobsApiLiveTest extends BaseJenkinsApiLiveTest {
         String config = payloadFromResource("/freestyle-project-sleep-10-task.xml");
         RequestStatus createStatus = api().create(null, FREESTYLE_JOB_NAME, config);
         assertTrue(createStatus.value());
-        IntegerResponse qId = api().build(null, FREESTYLE_JOB_NAME);
+        LongResponse qId = api().build(null, FREESTYLE_JOB_NAME);
         assertNotNull(qId);
         assertTrue(qId.value() > 0);
         QueueItem queueItem = getRunningQueueItem(qId.value());
@@ -73,7 +73,7 @@ public class JobsApiLiveTest extends BaseJenkinsApiLiveTest {
 
     @Test(dependsOnMethods = "testStopFreeStyleBuild")
     public void testTermFreeStyleBuild() throws InterruptedException {
-        IntegerResponse qId = api().build(null, FREESTYLE_JOB_NAME);
+        LongResponse qId = api().build(null, FREESTYLE_JOB_NAME);
         assertNotNull(qId);
         assertTrue(qId.value() > 0);
         QueueItem queueItem = getRunningQueueItem(qId.value());
@@ -95,7 +95,7 @@ public class JobsApiLiveTest extends BaseJenkinsApiLiveTest {
 
     @Test(dependsOnMethods = "testTermFreeStyleBuild")
     public void testKillFreeStyleBuild() throws InterruptedException {
-        IntegerResponse qId = api().build(null, FREESTYLE_JOB_NAME);
+        LongResponse qId = api().build(null, FREESTYLE_JOB_NAME);
         assertNotNull(qId);
         assertTrue(qId.value() > 0);
         QueueItem queueItem = getRunningQueueItem(qId.value());
@@ -126,7 +126,7 @@ public class JobsApiLiveTest extends BaseJenkinsApiLiveTest {
         String config = payloadFromResource("/pipeline.xml");
         RequestStatus createStatus = api().create(null, PIPELINE_JOB_NAME, config);
         assertTrue(createStatus.value());
-        IntegerResponse qId = api().build(null, PIPELINE_JOB_NAME);
+        LongResponse qId = api().build(null, PIPELINE_JOB_NAME);
         assertNotNull(qId);
         assertTrue(qId.value() > 0);
         QueueItem queueItem = getRunningQueueItem(qId.value());
@@ -141,7 +141,7 @@ public class JobsApiLiveTest extends BaseJenkinsApiLiveTest {
 
     @Test(dependsOnMethods = "testStopPipelineBuild")
     public void testTermPipelineBuild() throws InterruptedException {
-        IntegerResponse qId = api().build(null, PIPELINE_JOB_NAME);
+        LongResponse qId = api().build(null, PIPELINE_JOB_NAME);
         assertNotNull(qId);
         assertTrue(qId.value() > 0);
         QueueItem queueItem = getRunningQueueItem(qId.value());
@@ -156,7 +156,7 @@ public class JobsApiLiveTest extends BaseJenkinsApiLiveTest {
 
     @Test(dependsOnMethods = "testTermPipelineBuild")
     public void testKillPipelineBuild() throws InterruptedException {
-        IntegerResponse qId = api().build(null, PIPELINE_JOB_NAME);
+        LongResponse qId = api().build(null, PIPELINE_JOB_NAME);
         assertNotNull(qId);
         assertTrue(qId.value() > 0);
         QueueItem queueItem = getRunningQueueItem(qId.value());
@@ -241,7 +241,7 @@ public class JobsApiLiveTest extends BaseJenkinsApiLiveTest {
         BuildInfo output = api().buildInfo(null, "DevTest", buildNumber);
         assertNotNull(output);
         assertEquals("DevTest #" + buildNumber, output.fullDisplayName());
-        assertEquals((int) queueId.value(), output.queueId());
+        assertEquals((long) queueId.value(), output.queueId());
     }
 
     @Test(dependsOnMethods = "testGetBuildInfo")
@@ -255,7 +255,7 @@ public class JobsApiLiveTest extends BaseJenkinsApiLiveTest {
         String config = payloadFromResource("/pipeline-with-action.xml");
         RequestStatus createStatus = api().create(null, PIPELINE_WITH_ACTION_JOB_NAME, config);
         assertTrue(createStatus.value());
-        IntegerResponse qId = api().build(null, PIPELINE_WITH_ACTION_JOB_NAME);
+        LongResponse qId = api().build(null, PIPELINE_WITH_ACTION_JOB_NAME);
         assertNotNull(qId);
         assertTrue(qId.value() > 0);
         QueueItem queueItem = getRunningQueueItem(qId.value());
@@ -319,7 +319,7 @@ public class JobsApiLiveTest extends BaseJenkinsApiLiveTest {
     public void testBuildJobWithParameters() {
         Map<String, List<String>> params = new HashMap<>();
         params.put("SomeKey", Lists.newArrayList("SomeVeryNewValue"));
-        IntegerResponse output = api().buildWithParameters(null, "DevTest", params);
+        LongResponse output = api().buildWithParameters(null, "DevTest", params);
         assertNotNull(output);
         assertTrue(output.value() > 0);
         assertEquals(output.errors().size(), 0);
@@ -327,7 +327,7 @@ public class JobsApiLiveTest extends BaseJenkinsApiLiveTest {
 
     @Test(dependsOnMethods = "testBuildJobWithParameters")
     public void testBuildJobWithNullParametersMap() {
-        IntegerResponse output = api().buildWithParameters(null, "DevTest", null);
+        LongResponse output = api().buildWithParameters(null, "DevTest", null);
         assertNotNull(output);
         assertTrue(output.value() > 0);
         assertEquals(output.errors().size(), 0);
@@ -335,7 +335,7 @@ public class JobsApiLiveTest extends BaseJenkinsApiLiveTest {
 
     @Test(dependsOnMethods = "testBuildJobWithNullParametersMap")
     public void testBuildJobWithEmptyParametersMap() {
-        IntegerResponse output = api().buildWithParameters(null, "DevTest", new HashMap<>());
+        LongResponse output = api().buildWithParameters(null, "DevTest", new HashMap<>());
         assertNotNull(output);
         assertNull(output.value());
         assertEquals(output.errors().size(), 1);
@@ -508,7 +508,7 @@ public class JobsApiLiveTest extends BaseJenkinsApiLiveTest {
         BuildInfo output = api().buildInfo("test-folder/test-folder-1", "JobInFolder", 1);
         assertNotNull(output);
         assertTrue(output.fullDisplayName().contains("JobInFolder #1"));
-        assertEquals((int) queueIdForAnotherJob.value(), output.queueId());
+        assertEquals((long) queueIdForAnotherJob.value(), output.queueId());
     }
 
     @Test(dependsOnMethods = "testGetProgressiveText")
@@ -549,7 +549,7 @@ public class JobsApiLiveTest extends BaseJenkinsApiLiveTest {
         Map<String, List<String>> params = new HashMap<>();
         params.put("SomeKey1", Lists.newArrayList(""));
         params.put("SomeKey2", null);
-        IntegerResponse job1 = api.jobsApi().buildWithParameters(null, "JobForEmptyAndNullParams", params);
+        LongResponse job1 = api.jobsApi().buildWithParameters(null, "JobForEmptyAndNullParams", params);
         assertNotNull(job1);
         assertTrue(job1.value() > 0);
         assertEquals(job1.errors().size(), 0);
@@ -639,7 +639,7 @@ public class JobsApiLiveTest extends BaseJenkinsApiLiveTest {
 
     @Test
     public void testBuildNonExistentJob() {
-        IntegerResponse output = api().build(null, randomString());
+        LongResponse output = api().build(null, randomString());
         assertNotNull(output);
         assertNull(output.value());
         assertTrue(output.errors().size() > 0);
@@ -658,7 +658,7 @@ public class JobsApiLiveTest extends BaseJenkinsApiLiveTest {
     public void testBuildNonExistentJobWithParams() {
         Map<String, List<String>> params = new HashMap<>();
         params.put("SomeKey", Lists.newArrayList("SomeVeryNewValue"));
-        IntegerResponse output = api().buildWithParameters(null, randomString(), params);
+        LongResponse output = api().buildWithParameters(null, randomString(), params);
         assertNotNull(output);
         assertNull(output.value());
         assertTrue(output.errors().size() > 0);

--- a/src/test/java/com/cdancy/jenkins/rest/features/JobsApiMockTest.java
+++ b/src/test/java/com/cdancy/jenkins/rest/features/JobsApiMockTest.java
@@ -18,7 +18,7 @@ package com.cdancy.jenkins.rest.features;
 
 import com.cdancy.jenkins.rest.BaseJenkinsMockTest;
 import com.cdancy.jenkins.rest.JenkinsApi;
-import com.cdancy.jenkins.rest.domain.common.IntegerResponse;
+import com.cdancy.jenkins.rest.domain.common.LongResponse;
 import com.cdancy.jenkins.rest.domain.common.RequestStatus;
 import com.cdancy.jenkins.rest.domain.job.*;
 import com.google.common.collect.Lists;
@@ -477,9 +477,9 @@ public class JobsApiMockTest extends BaseJenkinsMockTest {
         JenkinsApi jenkinsApi = api(server.url("/").url());
         JobsApi api = jenkinsApi.jobsApi();
         try {
-            IntegerResponse output = api.build(null,"DevTest");
+            LongResponse output = api.build(null,"DevTest");
             assertNotNull(output);
-            assertEquals((int) output.value(), 1);
+            assertEquals((long) output.value(), 1);
             assertEquals(output.errors().size(), 0);
             assertSentAccept(server, "POST", "/job/DevTest/build", "application/unknown");
         } finally {
@@ -496,7 +496,7 @@ public class JobsApiMockTest extends BaseJenkinsMockTest {
         JenkinsApi jenkinsApi = api(server.url("/").url());
         JobsApi api = jenkinsApi.jobsApi();
         try {
-            IntegerResponse output = api.build(null,"DevTest");
+            LongResponse output = api.build(null,"DevTest");
             assertNotNull(output);
             assertNull(output.value());
             assertEquals(output.errors().size(), 1);
@@ -517,7 +517,7 @@ public class JobsApiMockTest extends BaseJenkinsMockTest {
         JenkinsApi jenkinsApi = api(server.url("/").url());
         JobsApi api = jenkinsApi.jobsApi();
         try {
-            IntegerResponse output = api.build(null, "DevTest");
+            LongResponse output = api.build(null, "DevTest");
             assertNotNull(output);
             assertNull(output.value());
             assertEquals(output.errors().size(), 1);
@@ -541,9 +541,9 @@ public class JobsApiMockTest extends BaseJenkinsMockTest {
         try {
             Map<String, List<String>> params = new HashMap<>();
             params.put("SomeKey", Lists.newArrayList("SomeVeryNewValue"));
-            IntegerResponse output = api.buildWithParameters(null, "DevTest", params);
+            LongResponse output = api.buildWithParameters(null, "DevTest", params);
             assertNotNull(output);
-            assertEquals((int) output.value(), 1);
+            assertEquals((long) output.value(), 1);
             assertEquals(output.errors().size(), 0);
             assertSentAccept(server, "POST", "/job/DevTest/buildWithParameters", "application/unknown");
         } finally {
@@ -560,9 +560,9 @@ public class JobsApiMockTest extends BaseJenkinsMockTest {
         JenkinsApi jenkinsApi = api(server.url("/").url());
         JobsApi api = jenkinsApi.jobsApi();
         try {
-            IntegerResponse output = api.buildWithParameters(null, "DevTest", null);
+            LongResponse output = api.buildWithParameters(null, "DevTest", null);
             assertNotNull(output);
-            assertEquals((int) output.value(), 1);
+            assertEquals((long) output.value(), 1);
             assertEquals(output.errors().size(), 0);
             assertSentAccept(server, "POST", "/job/DevTest/buildWithParameters", "application/unknown");
         } finally {
@@ -579,9 +579,9 @@ public class JobsApiMockTest extends BaseJenkinsMockTest {
         JenkinsApi jenkinsApi = api(server.url("/").url());
         JobsApi api = jenkinsApi.jobsApi();
         try {
-            IntegerResponse output = api.buildWithParameters(null, "DevTest", new HashMap<>());
+            LongResponse output = api.buildWithParameters(null, "DevTest", new HashMap<>());
             assertNotNull(output);
-            assertEquals((int) output.value(), 1);
+            assertEquals((long) output.value(), 1);
             assertEquals(output.errors().size(), 0);
             assertSentAccept(server, "POST", "/job/DevTest/buildWithParameters", "application/unknown");
         } finally {
@@ -599,7 +599,7 @@ public class JobsApiMockTest extends BaseJenkinsMockTest {
         try {
             Map<String, List<String>> params = new HashMap<>();
             params.put("SomeKey", Lists.newArrayList("SomeVeryNewValue"));
-            IntegerResponse output = api.buildWithParameters(null, "DevTest", params);
+            LongResponse output = api.buildWithParameters(null, "DevTest", params);
             assertNotNull(output);
             assertNull(output.value());
             assertEquals(output.errors().size(), 1);

--- a/src/test/java/com/cdancy/jenkins/rest/features/QueueApiLiveTest.java
+++ b/src/test/java/com/cdancy/jenkins/rest/features/QueueApiLiveTest.java
@@ -31,7 +31,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import com.cdancy.jenkins.rest.BaseJenkinsApiLiveTest;
-import com.cdancy.jenkins.rest.domain.common.IntegerResponse;
+import com.cdancy.jenkins.rest.domain.common.LongResponse;
 import com.cdancy.jenkins.rest.domain.common.RequestStatus;
 import com.cdancy.jenkins.rest.domain.queue.QueueItem;
 
@@ -58,10 +58,10 @@ public class QueueApiLiveTest extends BaseJenkinsApiLiveTest {
 
     @Test
     public void testGetQueue() {
-        IntegerResponse job1 = api.jobsApi().build(null, "QueueTest");
+        LongResponse job1 = api.jobsApi().build(null, "QueueTest");
         assertNotNull(job1);
         assertEquals(job1.errors().size(), 0);
-        IntegerResponse job2 = api.jobsApi().build(null, "QueueTest");
+        LongResponse job2 = api.jobsApi().build(null, "QueueTest");
         assertNotNull(job2);
         assertEquals(job2.errors().size(), 0);
         List<QueueItem> queueItems = api().queue();
@@ -78,10 +78,10 @@ public class QueueApiLiveTest extends BaseJenkinsApiLiveTest {
 
     @Test
     public void testGetPendingQueueItem() {
-        IntegerResponse job1 = api.jobsApi().build(null,"QueueTest");
+        LongResponse job1 = api.jobsApi().build(null,"QueueTest");
         assertNotNull(job1);
         assertEquals(job1.errors().size(), 0);
-        IntegerResponse job2 = api.jobsApi().build(null,"QueueTest");
+        LongResponse job2 = api.jobsApi().build(null,"QueueTest");
         assertNotNull(job2);
         assertEquals(job2.errors().size(), 0);
 
@@ -94,10 +94,10 @@ public class QueueApiLiveTest extends BaseJenkinsApiLiveTest {
 
     @Test
     public void testGetRunningQueueItem() throws InterruptedException {
-        IntegerResponse job1 = api.jobsApi().build(null,"QueueTest");
+        LongResponse job1 = api.jobsApi().build(null,"QueueTest");
         assertNotNull(job1);
         assertEquals(job1.errors().size(), 0);
-        IntegerResponse job2 = api.jobsApi().build(null,"QueueTest");
+        LongResponse job2 = api.jobsApi().build(null,"QueueTest");
         assertNotNull(job2);
         assertEquals(job2.errors().size(), 0);
 
@@ -121,7 +121,7 @@ public class QueueApiLiveTest extends BaseJenkinsApiLiveTest {
     public void testQueueItemSingleParameters() throws InterruptedException {
         Map<String, List<String>> params = new HashMap<>();
         params.put("SomeKey", Lists.newArrayList("SomeVeryNewValue1"));
-        IntegerResponse job1 = api.jobsApi().buildWithParameters(null,"QueueTestSingleParam", params);
+        LongResponse job1 = api.jobsApi().buildWithParameters(null,"QueueTestSingleParam", params);
         assertNotNull(job1);
         assertTrue(job1.value() > 0);
         assertEquals(job1.errors().size(), 0);
@@ -130,7 +130,7 @@ public class QueueApiLiveTest extends BaseJenkinsApiLiveTest {
         // So we must set some different parameter values
         params = new HashMap<>();
         params.put("SomeKey", Lists.newArrayList("SomeVeryNewValue2"));
-        IntegerResponse job2 = api.jobsApi().buildWithParameters(null,"QueueTestSingleParam", params);
+        LongResponse job2 = api.jobsApi().buildWithParameters(null,"QueueTestSingleParam", params);
         assertNotNull(job2);
         assertTrue(job2.value() > 0);
         assertEquals(job2.errors().size(), 0);
@@ -148,7 +148,7 @@ public class QueueApiLiveTest extends BaseJenkinsApiLiveTest {
     public void testQueueItemMultipleParameters() throws InterruptedException {
         Map<String, List<String>> params = new HashMap<>();
         params.put("SomeKey1", Lists.newArrayList("SomeVeryNewValue1"));
-        IntegerResponse job1 = api.jobsApi().buildWithParameters(null, "QueueTestMultipleParams",params);
+        LongResponse job1 = api.jobsApi().buildWithParameters(null, "QueueTestMultipleParams",params);
         assertNotNull(job1);
         assertTrue(job1.value() > 0);
         assertEquals(job1.errors().size(), 0);
@@ -157,7 +157,7 @@ public class QueueApiLiveTest extends BaseJenkinsApiLiveTest {
         // So we must set some different parameter values
         params = new HashMap<>();
         params.put("SomeKey1", Lists.newArrayList("SomeVeryNewValue2"));
-        IntegerResponse job2 = api.jobsApi().buildWithParameters(null, "QueueTestMultipleParams", params);
+        LongResponse job2 = api.jobsApi().buildWithParameters(null, "QueueTestMultipleParams", params);
         assertNotNull(job2);
         assertTrue(job2.value() > 0);
         assertEquals(job2.errors().size(), 0);
@@ -177,7 +177,7 @@ public class QueueApiLiveTest extends BaseJenkinsApiLiveTest {
     public void testQueueItemEmptyParameterValue() throws InterruptedException {
         Map<String, List<String>> params = new HashMap<>();
         params.put("SomeKey1", Lists.newArrayList(""));
-        IntegerResponse job1 = api.jobsApi().buildWithParameters(null, "QueueTestMultipleParams",params);
+        LongResponse job1 = api.jobsApi().buildWithParameters(null, "QueueTestMultipleParams",params);
         assertNotNull(job1);
         assertTrue(job1.value() > 0);
         assertEquals(job1.errors().size(), 0);
@@ -194,10 +194,10 @@ public class QueueApiLiveTest extends BaseJenkinsApiLiveTest {
 
     @Test
     public void testGetCancelledQueueItem() {
-        IntegerResponse job1 = api.jobsApi().build(null,"QueueTest");
+        LongResponse job1 = api.jobsApi().build(null,"QueueTest");
         assertNotNull(job1);
         assertEquals(job1.errors().size(), 0);
-        IntegerResponse job2 = api.jobsApi().build(null, "QueueTest");
+        LongResponse job2 = api.jobsApi().build(null, "QueueTest");
         assertNotNull(job2);
         assertEquals(job2.errors().size(), 0);
 


### PR DESCRIPTION
Queue ID retured from Jenkins can be a Long value. This is due to a recent update which resulted in the queue IDs returning a random long values instead of sequential integers. The jenkins-rest API expects this to be an Integer value. As a result, calls to jobsApi().buildWithParameters and then attempting to retrieve the queue ID will fail/return null.

This PR fixes the JobsApi and QueueApi to deal with the new long values.

Please refer to issue [315](https://github.com/cdancy/jenkins-rest/issues/315)

closes #315 
