### PR TITLE
The StageFlowNode   node add id field

### DIFF
--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG jenkins_tag=2.401.3-lts-jdk17
+ARG jenkins_tag=2.414.3-lts-jdk17
 FROM jenkins/jenkins:$jenkins_tag
 
 COPY --chown=jenkins:jenkins init.groovy.d/ /usr/share/jenkins/ref/init.groovy.d/

--- a/src/main/java/com/cdancy/jenkins/rest/domain/job/StageFlowNode.java
+++ b/src/main/java/com/cdancy/jenkins/rest/domain/job/StageFlowNode.java
@@ -24,7 +24,7 @@ import org.jclouds.json.SerializedNames;
 
 @AutoValue
 public abstract class StageFlowNode {
-
+   public abstract Integer id();
    public abstract String name();
 
    public abstract String status();
@@ -38,8 +38,8 @@ public abstract class StageFlowNode {
    StageFlowNode() {
    }
 
-   @SerializedNames({ "name", "status", "startTimeMillis", "durationTimeMillis", "parentNodes" })
-   public static StageFlowNode create(String name, String status, long startTimeMillis, long durationTimeMillis, List<Long> parentNodes) {
-      return new AutoValue_StageFlowNode(name, status, startTimeMillis, durationTimeMillis, parentNodes);
+   @SerializedNames({ "id","name", "status", "startTimeMillis", "durationTimeMillis", "parentNodes" })
+   public static StageFlowNode create(Integer id,String name, String status, long startTimeMillis, long durationTimeMillis, List<Long> parentNodes) {
+      return new AutoValue_StageFlowNode(id,name, status, startTimeMillis, durationTimeMillis, parentNodes);
    }
 }


### PR DESCRIPTION
https://github.com/cdancy/jenkins-rest/issues/360
The StageFlowNode is missing the ID field, which causes the corresponding NodeId field to be missing when calling the JobsApi.pipelineNodeLog() method